### PR TITLE
Bump opencode feature version to 1.0.1

### DIFF
--- a/src/opencode/devcontainer-feature.json
+++ b/src/opencode/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "opencode",
     "id": "opencode",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs opencode CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/opencode",
     "options": {


### PR DESCRIPTION
## Summary
- bump opencode feature version to 1.0.1 so publishing is not skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (1.0.1) released with no functional changes or impact on existing features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->