### PR TITLE
Harden opencode host target path handling

### DIFF
--- a/src/opencode/host/opencode-auth-copy
+++ b/src/opencode/host/opencode-auth-copy
@@ -2,7 +2,19 @@
 set -e
 
 TEMP_DIR=${TEMP:-"/tmp"}
+
+while [ "${TEMP_DIR}" != "/" ] && [ "${TEMP_DIR%/}" != "${TEMP_DIR}" ]; do
+    TEMP_DIR=${TEMP_DIR%/}
+done
+
 TARGET_DIR="${TEMP_DIR}/opencode"
+
+case "${TARGET_DIR}" in
+    ""|"/"|"."|"..")
+        echo "Refusing unsafe target path: ${TARGET_DIR}"
+        exit 1
+        ;;
+esac
 
 if [ -n "${OPENCODE_CONFIG_DIR:-}" ]; then
     SOURCE_DIR="${OPENCODE_CONFIG_DIR}"
@@ -10,15 +22,17 @@ else
     SOURCE_DIR="${HOME}/.local/share/opencode"
 fi
 
+if [ -L "${TARGET_DIR}" ]; then
+    CURRENT_LINK=$(readlink "${TARGET_DIR}" || true)
+    if [ "${CURRENT_LINK}" = "${SOURCE_DIR}" ]; then
+        exit 0
+    fi
+
+    rm "${TARGET_DIR}"
+fi
+
 if [ -d "${SOURCE_DIR}" ]; then
     mkdir -p "$(dirname "${TARGET_DIR}")"
-
-    if [ -L "${TARGET_DIR}" ]; then
-        CURRENT_LINK=$(readlink "${TARGET_DIR}" || true)
-        if [ "${CURRENT_LINK}" = "${SOURCE_DIR}" ]; then
-            exit 0
-        fi
-    fi
 
     if [ -e "${TARGET_DIR}" ]; then
         rm -rf "${TARGET_DIR}"

--- a/src/opencode/host/opencode-auth-copy.cmd
+++ b/src/opencode/host/opencode-auth-copy.cmd
@@ -4,7 +4,42 @@ setlocal
 set "TEMP_DIR=%TEMP%"
 if "%TEMP_DIR%"=="" set "TEMP_DIR=/tmp"
 
+:trim_temp_dir
+if "%TEMP_DIR:~-1%"=="\" (
+    if /I not "%TEMP_DIR:~1,2%"==":\" (
+        set "TEMP_DIR=%TEMP_DIR:~0,-1%"
+        goto trim_temp_dir
+    )
+)
+if "%TEMP_DIR:~-1%"=="/" (
+    if /I not "%TEMP_DIR:~1,2%"==":/" (
+        set "TEMP_DIR=%TEMP_DIR:~0,-1%"
+        goto trim_temp_dir
+    )
+)
+
 set "TARGET_DIR=%TEMP_DIR%\opencode"
+
+if "%TARGET_DIR%"=="" (
+    echo Refusing unsafe target path: %TARGET_DIR%
+    exit /b 1
+)
+if "%TARGET_DIR%"=="\" (
+    echo Refusing unsafe target path: %TARGET_DIR%
+    exit /b 1
+)
+if "%TARGET_DIR%"=="/" (
+    echo Refusing unsafe target path: %TARGET_DIR%
+    exit /b 1
+)
+if "%TARGET_DIR%"=="." (
+    echo Refusing unsafe target path: %TARGET_DIR%
+    exit /b 1
+)
+if "%TARGET_DIR%"==".." (
+    echo Refusing unsafe target path: %TARGET_DIR%
+    exit /b 1
+)
 
 if not "%OPENCODE_CONFIG_DIR%"=="" (
     set "SOURCE_DIR=%OPENCODE_CONFIG_DIR%"


### PR DESCRIPTION
## Summary
- Normalize `TEMP` path handling in host helper scripts before deriving the opencode target path.
- Add guard rails to refuse unsafe target values before any delete operations.
- Preserve an existing POSIX symlink when `/tmp/opencode` already points to the selected source directory.

## Context
- Follow-up request from this thread to keep correct links in place and sanitize target path handling.
- Related follow-up issue for Windows no-op parity: #54.

## Testing
- Not run (script-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced path handling and normalization for directory operations.
* Strengthened safety validation to prevent operations on unsafe or invalid paths.
* Improved symlink detection and handling to avoid conflicts during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->