### PR TITLE
fix: revert opencode copyAuth to auth.json copy

### DIFF
--- a/src/opencode/NOTES.md
+++ b/src/opencode/NOTES.md
@@ -2,12 +2,11 @@
 
 - `version` supports `latest` (resolved from the GitHub releases latest tag) or an explicit version (with or without a leading `v`).
 - The installer ensures `ripgrep` (`rg`) is present because `opencode` requires it.
-- `copyAuth` enables a startup hook that symlinks `$HOME/.local/share/opencode` to `/tmp/opencode-host-tmp` for persistent profile and chat history data.
+- `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
-- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script and source profile data from either:
-  - `${OPENCODE_CONFIG_DIR}` when set, or
-  - the default storage directory (`~/.local/share/opencode` on macOS/Linux, `%USERPROFILE%\.local\share\opencode` on Windows).
-  If the source directory exists, the script links `${TEMP}/opencode` to it. Otherwise it creates an empty `${TEMP}/opencode` directory.
+- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script and copy `auth.json` from either:
+  - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
+  - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).
 - Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):
 
 ```json

--- a/src/opencode/README.md
+++ b/src/opencode/README.md
@@ -22,12 +22,11 @@ Installs opencode CLI on Wolfi base images.
 
 - `version` supports `latest` (resolved from the GitHub releases latest tag) or an explicit version (with or without a leading `v`).
 - The installer ensures `ripgrep` (`rg`) is present because `opencode` requires it.
-- `copyAuth` enables a startup hook that symlinks `$HOME/.local/share/opencode` to `/tmp/opencode-host-tmp` for persistent profile and chat history data.
+- `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
-- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script and source profile data from either:
-  - `${OPENCODE_CONFIG_DIR}` when set, or
-  - the default storage directory (`~/.local/share/opencode` on macOS/Linux, `%USERPROFILE%\.local\share\opencode` on Windows).
-  If the source directory exists, the script links `${TEMP}/opencode` to it. Otherwise it creates an empty `${TEMP}/opencode` directory.
+- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script and copy `auth.json` from either:
+  - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
+  - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).
 - Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):
 
 ```json

--- a/src/opencode/devcontainer-feature.json
+++ b/src/opencode/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "opencode",
     "id": "opencode",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "Installs opencode CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/opencode",
     "options": {
@@ -13,7 +13,7 @@
         "copyAuth": {
             "type": "boolean",
             "default": false,
-            "description": "Whether to persist host opencode profile data in the container via a shared temp mount and symlink."
+            "description": "Whether to copy opencode auth.json from the host into the container."
         }
     },
     "mounts": [

--- a/src/opencode/host/opencode-auth-copy
+++ b/src/opencode/host/opencode-auth-copy
@@ -3,31 +3,17 @@ set -e
 
 TEMP_DIR=${TEMP:-"/tmp"}
 TARGET_DIR="${TEMP_DIR}/opencode"
+TARGET_AUTH="${TARGET_DIR}/auth.json"
 
 if [ -n "${OPENCODE_CONFIG_DIR:-}" ]; then
-    SOURCE_DIR="${OPENCODE_CONFIG_DIR}"
+    SOURCE_AUTH="${OPENCODE_CONFIG_DIR}/auth.json"
 else
-    SOURCE_DIR="${HOME}/.local/share/opencode"
+    SOURCE_AUTH="${HOME}/.local/share/opencode/auth.json"
 fi
 
-if [ -d "${SOURCE_DIR}" ]; then
-    mkdir -p "$(dirname "${TARGET_DIR}")"
+mkdir -p "${TARGET_DIR}"
 
-    if [ -L "${TARGET_DIR}" ]; then
-        CURRENT_LINK=$(readlink "${TARGET_DIR}" || true)
-        if [ "${CURRENT_LINK}" = "${SOURCE_DIR}" ]; then
-            exit 0
-        fi
-    fi
-
-    if [ -e "${TARGET_DIR}" ]; then
-        rm -rf "${TARGET_DIR}"
-    fi
-
-    ln -s "${SOURCE_DIR}" "${TARGET_DIR}"
-else
-    if [ -L "${TARGET_DIR}" ]; then
-        rm "${TARGET_DIR}"
-    fi
-    mkdir -p "${TARGET_DIR}"
+if [ -f "${SOURCE_AUTH}" ]; then
+    cp "${SOURCE_AUTH}" "${TARGET_AUTH}"
+    chmod 600 "${TARGET_AUTH}"
 fi

--- a/src/opencode/host/opencode-auth-copy.cmd
+++ b/src/opencode/host/opencode-auth-copy.cmd
@@ -5,27 +5,18 @@ set "TEMP_DIR=%TEMP%"
 if "%TEMP_DIR%"=="" set "TEMP_DIR=/tmp"
 
 set "TARGET_DIR=%TEMP_DIR%\opencode"
+set "TARGET_AUTH=%TARGET_DIR%\auth.json"
 
 if not "%OPENCODE_CONFIG_DIR%"=="" (
-    set "SOURCE_DIR=%OPENCODE_CONFIG_DIR%"
+    set "SOURCE_AUTH=%OPENCODE_CONFIG_DIR%\auth.json"
 ) else (
-    set "SOURCE_DIR=%USERPROFILE%\.local\share\opencode"
+    set "SOURCE_AUTH=%USERPROFILE%\.local\share\opencode\auth.json"
 )
 
-if exist "%SOURCE_DIR%\" (
-    if exist "%TARGET_DIR%" (
-        rmdir /S /Q "%TARGET_DIR%" >nul 2>&1
-    )
+if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
 
-    mklink /J "%TARGET_DIR%" "%SOURCE_DIR%" >nul 2>&1
-    if errorlevel 1 (
-        if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
-    )
-) else (
-    if exist "%TARGET_DIR%" (
-        rmdir /S /Q "%TARGET_DIR%" >nul 2>&1
-    )
-    if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+if exist "%SOURCE_AUTH%" (
+    copy /Y "%SOURCE_AUTH%" "%TARGET_AUTH%" >nul
 )
 
 endlocal

--- a/src/opencode/install.sh
+++ b/src/opencode/install.sh
@@ -84,39 +84,21 @@ if ! command -v opencode >/dev/null 2>&1; then
     exit 1
 fi
 
-echo "Installing opencode persistence hook"
+echo "Installing opencode auth copy hook"
 mkdir -p /usr/local/share
 
 cat << 'EOF' > /usr/local/share/opencode-auth-copy.sh
 #!/bin/sh
 set -e
 
-SOURCE_DIR="/tmp/opencode-host-tmp"
+SOURCE_AUTH="/tmp/opencode-host-tmp/auth.json"
 FLAG_FILE="/usr/local/share/opencode-copyauth.flag"
-TARGET_DIR="${HOME}/.local/share/opencode"
+TARGET_AUTH="${HOME}/.local/share/opencode/auth.json"
 
-if [ -f "${FLAG_FILE}" ]; then
-    mkdir -p "${SOURCE_DIR}"
-    mkdir -p "$(dirname "${TARGET_DIR}")"
-
-    if [ -L "${TARGET_DIR}" ]; then
-        CURRENT_LINK=$(readlink "${TARGET_DIR}" || true)
-        if [ "${CURRENT_LINK}" != "${SOURCE_DIR}" ]; then
-            rm "${TARGET_DIR}"
-            ln -s "${SOURCE_DIR}" "${TARGET_DIR}"
-        fi
-    elif [ -e "${TARGET_DIR}" ]; then
-        if [ -d "${TARGET_DIR}" ]; then
-            if ! cp -R "${TARGET_DIR}/." "${SOURCE_DIR}/"; then
-                echo "Warning: failed to migrate existing profile data from ${TARGET_DIR} to ${SOURCE_DIR}; keeping existing directory"
-                exit 0
-            fi
-        fi
-        rm -rf "${TARGET_DIR}"
-        ln -s "${SOURCE_DIR}" "${TARGET_DIR}"
-    else
-        ln -s "${SOURCE_DIR}" "${TARGET_DIR}"
-    fi
+if [ -f "${FLAG_FILE}" ] && [ -f "${SOURCE_AUTH}" ]; then
+    mkdir -p "$(dirname "${TARGET_AUTH}")"
+    cp "${SOURCE_AUTH}" "${TARGET_AUTH}"
+    chmod 600 "${TARGET_AUTH}"
 fi
 
 EOF

--- a/test/opencode/default.sh
+++ b/test/opencode/default.sh
@@ -19,7 +19,7 @@ if [ -z "${TARGET_HOME}" ]; then
     TARGET_HOME="/root"
 fi
 
-TARGET_PROFILE_DIR="${TARGET_HOME}/.local/share/opencode"
-check "profile symlink missing" test ! -L "${TARGET_PROFILE_DIR}"
+TARGET_AUTH="${TARGET_HOME}/.local/share/opencode/auth.json"
+check "auth file missing" test ! -f "${TARGET_AUTH}"
 
 reportResults

--- a/test/opencode/with_auth.sh
+++ b/test/opencode/with_auth.sh
@@ -15,18 +15,16 @@ if [ -z "${TARGET_HOME}" ]; then
     TARGET_HOME="/root"
 fi
 
-TARGET_PROFILE_DIR="${TARGET_HOME}/.local/share/opencode"
-SOURCE_PROFILE_DIR="/tmp/opencode-host-tmp"
+TARGET_AUTH="${TARGET_HOME}/.local/share/opencode/auth.json"
+SOURCE_AUTH="/tmp/opencode-host-tmp/auth.json"
 
 check "auth copy hook installed" test -f /usr/local/share/opencode-auth-copy.sh
 check "auth copy flag installed" test -f /usr/local/share/opencode-copyauth.flag
-check "profile symlink enabled" test -L "${TARGET_PROFILE_DIR}"
-check "profile symlink target" test "$(readlink "${TARGET_PROFILE_DIR}")" = "${SOURCE_PROFILE_DIR}"
 
-if [ -f "${SOURCE_PROFILE_DIR}/auth.json" ]; then
-    check "auth visible" test -f "${TARGET_PROFILE_DIR}/auth.json"
+if [ -f "${SOURCE_AUTH}" ]; then
+    check "auth copied" test -f "${TARGET_AUTH}"
 else
-    check "auth absent" test ! -f "${TARGET_PROFILE_DIR}/auth.json"
+    check "auth missing on host" test ! -f "${TARGET_AUTH}"
 fi
 
 reportResults


### PR DESCRIPTION
## Summary
- revert opencode copyAuth behavior from profile symlink persistence back to auth.json file copy
- update host helper scripts (POSIX and Windows), installer hook, and opencode tests to match copy semantics
- bump opencode feature version from 1.3.0 to 1.4.0 and refresh docs/notes wording

## Validation
- devcontainer features test -f opencode --skip-autogenerated --skip-duplicated .

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the OPENCODE_CONFIG_DIR environment variable to specify custom authentication configuration locations.

* **Refactor**
  * Changed authentication deployment from symlink-based persistence to direct file copying mechanism.

* **Documentation**
  * Updated guides to reflect new authentication handling behavior and configuration options.

* **Tests**
  * Updated validation tests for new file copying mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->