### PR TITLE
Add chromium feature with optional version pinning

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         features:
           - bash
+          - chromium
           - docker-outside-of-docker
           - claude
           - cursor

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Most of the features available for devcontainers usually expect you to run a deb
 The following features are available:
 
 - [bash](./src/bash/README.md) - Installs bash and common shell utilities on Wolfi base images
+- [chromium](./src/chromium/README.md) - Installs Chromium browser on Wolfi base images
 - [docker-outside-of-docker](./src/docker-outside-of-docker/README.md) - Enables Docker-in-Docker functionality for development containers
 - [node](./src/node/README.md) - Installs Node.js and common Node.js utilities on Wolfi base images
 - [opencode](./src/opencode/README.md) - Installs opencode CLI on Wolfi base images

--- a/src/chromium/NOTES.md
+++ b/src/chromium/NOTES.md
@@ -1,0 +1,4 @@
+## Usage notes
+
+- `version` supports `latest` (install current package) or an explicit Wolfi apk package version like `144.0.7559.109-r2`.
+- This feature targets headless browser workflows such as Playwright and MCP clients in Wolfi-based devcontainers.

--- a/src/chromium/README.md
+++ b/src/chromium/README.md
@@ -1,0 +1,24 @@
+
+# chromium (chromium)
+
+Installs Chromium browser on Wolfi base images.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/chromium:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Version of chromium to install (use 'latest' or a specific apk version). | string | latest |
+
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/chromium/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/chromium/devcontainer-feature.json
+++ b/src/chromium/devcontainer-feature.json
@@ -1,0 +1,14 @@
+{
+    "name": "chromium",
+    "id": "chromium",
+    "version": "1.0.0",
+    "description": "Installs Chromium browser on Wolfi base images.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/chromium",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of chromium to install (use 'latest' or a specific apk version)."
+        }
+    }
+}

--- a/src/chromium/install.sh
+++ b/src/chromium/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+VERSION=${VERSION:-"latest"}
+
+echo "Installing chromium..."
+
+apk update
+if [ "${VERSION}" = "latest" ]; then
+    apk add --no-cache chromium
+else
+    apk add --no-cache "chromium=${VERSION}"
+fi
+
+if ! command -v chromium >/dev/null 2>&1; then
+    echo "chromium installation failed"
+    exit 1
+fi
+
+echo "chromium installed successfully"

--- a/test/chromium/default.sh
+++ b/test/chromium/default.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "chromium package installed" apk info -e chromium
+check "chromium binary exists" test -x /usr/bin/chromium
+
+reportResults

--- a/test/chromium/scenarios.json
+++ b/test/chromium/scenarios.json
@@ -1,0 +1,18 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "chromium": {}
+        }
+    },
+    "version_144_0_7559_109_r2": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "chromium": {
+                "version": "144.0.7559.109-r2"
+            }
+        }
+    }
+}

--- a/test/chromium/version_144_0_7559_109_r2.sh
+++ b/test/chromium/version_144_0_7559_109_r2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "chromium package installed" apk info -e chromium
+check "chromium pinned version" bash -lc "apk list --installed chromium | grep 'chromium-144.0.7559.109-r2'"
+
+reportResults


### PR DESCRIPTION
## Summary
- add a new `chromium` feature that installs Chromium on Wolfi base images
- support a `version` option (`latest` by default or an explicit apk package version such as `144.0.7559.109-r2`)
- add scenario coverage for default install and pinned install, and include `chromium` in the CI test matrix

## Testing
- `devcontainer features test -f chromium --skip-autogenerated --skip-duplicated .`

Closes #58