### PR TITLE
Add gh feature with config copy and optional git auth

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
           - claude
           - cursor
           - git-user-profile
+          - gh
           - glab
           - node
           - opencode

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following features are available:
 - [chromium](./src/chromium/README.md) - Installs Chromium browser on Wolfi base images
 - [common-utils](./src/common-utils/README.md) - Installs common command line utilities, configures users, and optionally sets up Zsh on Wolfi base images (lean Wolfi-native variant)
 - [docker-outside-of-docker](./src/docker-outside-of-docker/README.md) - Enables Docker-in-Docker functionality for development containers
+- [gh](./src/gh/README.md) - Installs GitHub CLI (gh) on Wolfi base images
 - [node](./src/node/README.md) - Installs Node.js and common Node.js utilities on Wolfi base images
 - [opencode](./src/opencode/README.md) - Installs opencode CLI on Wolfi base images
 - [python](./src/python/README.md) - Installs Python and common Python utilities on Wolfi base images

--- a/src/gh/NOTES.md
+++ b/src/gh/NOTES.md
@@ -1,0 +1,12 @@
+## Usage notes
+
+- `version` supports `latest` or a specific apk version string (for example, `2.81.0-r0`).
+- `copyConfig` enables a startup hook that copies `/tmp/gh-host-tmp/hosts.yml` into `$HOME/.config/gh/hosts.yml`.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/gh` to `/tmp/gh-host-tmp`.
+- Use the host scripts in `src/gh/host/gh-config-copy` (POSIX) and `src/gh/host/gh-config-copy.cmd` (Windows). Call the shared base name `gh-config-copy` from `initializeCommand` so each OS resolves the right script and copy `hosts.yml` from `~/.config/gh/hosts.yml`.
+- Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/gh-config-copy"
+```
+- `useGitAuth` configures a scoped git credential helper for the repository `origin` remote when it is HTTPS. SSH remotes are detected and skipped with a warning.

--- a/src/gh/README.md
+++ b/src/gh/README.md
@@ -1,0 +1,38 @@
+
+# gh (gh)
+
+Installs GitHub CLI (gh) on Wolfi base images.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/gh:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Version of gh to install (use 'latest' or a specific apk version). | string | latest |
+| copyConfig | Whether to copy gh hosts.yml from the host into the container. | boolean | false |
+| useGitAuth | Whether to configure git credential helper for the repository remote using gh. | boolean | false |
+
+## Usage notes
+
+- `version` supports `latest` or a specific apk version string (for example, `2.81.0-r0`).
+- `copyConfig` enables a startup hook that copies `/tmp/gh-host-tmp/hosts.yml` into `$HOME/.config/gh/hosts.yml`.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/gh` to `/tmp/gh-host-tmp`.
+- Use the host scripts in `src/gh/host/gh-config-copy` (POSIX) and `src/gh/host/gh-config-copy.cmd` (Windows). Call the shared base name `gh-config-copy` from `initializeCommand` so each OS resolves the right script and copy `hosts.yml` from `~/.config/gh/hosts.yml`.
+- Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/gh-config-copy"
+```
+- `useGitAuth` configures a scoped git credential helper for the repository `origin` remote when it is HTTPS. SSH remotes are detected and skipped with a warning.
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/gh/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/gh/devcontainer-feature.json
+++ b/src/gh/devcontainer-feature.json
@@ -1,0 +1,32 @@
+{
+    "name": "gh",
+    "id": "gh",
+    "version": "1.0.0",
+    "description": "Installs GitHub CLI (gh) on Wolfi base images.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/gh",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of gh to install (use 'latest' or a specific apk version)."
+        },
+        "copyConfig": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to copy gh hosts.yml from the host into the container."
+        },
+        "useGitAuth": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to configure git credential helper for the repository remote using gh."
+        }
+    },
+    "mounts": [
+        {
+            "source": "${localEnv:TEMP:/tmp}/gh",
+            "target": "/tmp/gh-host-tmp",
+            "type": "bind"
+        }
+    ],
+    "postStartCommand": "/usr/local/share/gh-config-copy.sh"
+}

--- a/src/gh/host/gh-config-copy
+++ b/src/gh/host/gh-config-copy
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+TEMP_DIR=${TEMP:-"/tmp"}
+TARGET_DIR="${TEMP_DIR}/gh"
+TARGET_CONFIG="${TARGET_DIR}/hosts.yml"
+SOURCE_CONFIG="${HOME}/.config/gh/hosts.yml"
+
+mkdir -p "${TARGET_DIR}"
+
+if [ -f "${SOURCE_CONFIG}" ]; then
+    cp "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
+    chmod 600 "${TARGET_CONFIG}"
+fi

--- a/src/gh/host/gh-config-copy.cmd
+++ b/src/gh/host/gh-config-copy.cmd
@@ -1,0 +1,18 @@
+@echo off
+setlocal
+
+set "TEMP_DIR=%TEMP%"
+if "%TEMP_DIR%"=="" set "TEMP_DIR=%TMP%"
+if "%TEMP_DIR%"=="" set "TEMP_DIR=%SystemRoot%\Temp"
+
+set "TARGET_DIR=%TEMP_DIR%\gh"
+set "TARGET_CONFIG=%TARGET_DIR%\hosts.yml"
+set "SOURCE_CONFIG=%USERPROFILE%\.config\gh\hosts.yml"
+
+if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+
+if exist "%SOURCE_CONFIG%" (
+    copy /Y "%SOURCE_CONFIG%" "%TARGET_CONFIG%" >nul
+)
+
+endlocal

--- a/src/gh/install.sh
+++ b/src/gh/install.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+set -e
+
+VERSION=${VERSION:-"latest"}
+COPY_CONFIG=${COPYCONFIG:-"false"}
+USE_GIT_AUTH=${USEGITAUTH:-"false"}
+
+echo "Installing gh..."
+
+apk update
+if [ "${VERSION}" = "latest" ]; then
+    apk add --no-cache gh
+else
+    apk add --no-cache "gh=${VERSION}"
+fi
+
+if [ "${USE_GIT_AUTH}" = "true" ]; then
+    apk add --no-cache git
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh installation failed"
+    exit 1
+fi
+
+echo "Installing gh config copy hook"
+mkdir -p /usr/local/share
+
+cat << 'EOF' > /usr/local/share/gh-config-copy.sh
+#!/bin/sh
+set -e
+
+SOURCE_CONFIG="/tmp/gh-host-tmp/hosts.yml"
+FLAG_FILE="/usr/local/share/gh-copyconfig.flag"
+AUTH_FLAG_FILE="/usr/local/share/gh-git-auth.flag"
+TARGET_CONFIG="${HOME}/.config/gh/hosts.yml"
+
+if [ -f "${FLAG_FILE}" ] && [ -f "${SOURCE_CONFIG}" ]; then
+    mkdir -p "$(dirname "${TARGET_CONFIG}")"
+    cp "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
+    chmod 600 "${TARGET_CONFIG}"
+fi
+
+if [ -f "${AUTH_FLAG_FILE}" ]; then
+    if command -v git >/dev/null 2>&1; then
+        WORKSPACE_DIR="${WORKSPACE_FOLDER:-}"
+        if [ -z "${WORKSPACE_DIR}" ]; then
+            CURRENT_DIR=$(pwd)
+            if git -C "${CURRENT_DIR}" rev-parse --show-toplevel >/dev/null 2>&1; then
+                WORKSPACE_DIR=$(git -C "${CURRENT_DIR}" rev-parse --show-toplevel)
+            fi
+        fi
+        if [ -z "${WORKSPACE_DIR}" ] && [ -d "/workspaces" ]; then
+            for candidate in /workspaces/*; do
+                if [ -d "${candidate}" ] && git -C "${candidate}" rev-parse --show-toplevel >/dev/null 2>&1; then
+                    WORKSPACE_DIR=$(git -C "${candidate}" rev-parse --show-toplevel)
+                    break
+                fi
+            done
+        fi
+
+        if [ -z "${WORKSPACE_DIR}" ]; then
+            echo "Workspace not found; skipping gh git auth configuration"
+        else
+            REMOTE_URL=$(git -C "${WORKSPACE_DIR}" remote get-url origin 2>/dev/null || true)
+            if [ -z "${REMOTE_URL}" ]; then
+                echo "No origin remote found; skipping gh git auth configuration"
+            else
+                case "${REMOTE_URL}" in
+                    git@*|ssh://*)
+                        echo "SSH remote detected (${REMOTE_URL}); skipping gh git auth configuration"
+                        ;;
+                    *)
+                        git config --global "credential.${REMOTE_URL}.helper" "!gh auth git-credential"
+                        echo "Configured gh git auth for ${REMOTE_URL}"
+                        ;;
+                esac
+            fi
+        fi
+    else
+        echo "git not found; skipping gh git auth configuration"
+    fi
+fi
+
+EOF
+
+chmod +x /usr/local/share/gh-config-copy.sh
+
+if [ "${COPY_CONFIG}" = "true" ]; then
+    echo "Enabling gh config copy"
+    : > /usr/local/share/gh-copyconfig.flag
+fi
+
+if [ "${USE_GIT_AUTH}" = "true" ]; then
+    echo "Enabling gh git auth"
+    : > /usr/local/share/gh-git-auth.flag
+fi
+
+echo "gh installed successfully"

--- a/test/gh/default.sh
+++ b/test/gh/default.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "gh installed" gh --version
+check "config copy flag missing" test ! -f /usr/local/share/gh-copyconfig.flag
+
+reportResults

--- a/test/gh/scenarios.json
+++ b/test/gh/scenarios.json
@@ -1,0 +1,36 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "initializeCommand": {
+            "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/gh || true"
+        },
+        "features": {
+            "bash": {},
+            "gh": {}
+        }
+    },
+    "with_config": {
+        "image": "chainguard/wolfi-base:latest",
+        "initializeCommand": {
+            "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/gh || true"
+        },
+        "features": {
+            "bash": {},
+            "gh": {
+                "copyConfig": true
+            }
+        }
+    },
+    "with_git_auth": {
+        "image": "chainguard/wolfi-base:latest",
+        "initializeCommand": {
+            "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/gh || true"
+        },
+        "features": {
+            "bash": {},
+            "gh": {
+                "useGitAuth": true
+            }
+        }
+    }
+}

--- a/test/gh/with_config.sh
+++ b/test/gh/with_config.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+TARGET_HOME="${HOME}"
+if [ -z "${TARGET_HOME}" ]; then
+    TARGET_HOME="${_REMOTE_USER_HOME}"
+fi
+if [ -z "${TARGET_HOME}" ]; then
+    if [ -n "${_REMOTE_USER:-}" ]; then
+        TARGET_HOME=$(grep -E "^${_REMOTE_USER}:" /etc/passwd | cut -d: -f6)
+    fi
+fi
+if [ -z "${TARGET_HOME}" ]; then
+    TARGET_HOME="/root"
+fi
+
+TARGET_CONFIG="${TARGET_HOME}/.config/gh/hosts.yml"
+SOURCE_CONFIG="/tmp/gh-host-tmp/hosts.yml"
+
+check "config copy hook installed" test -f /usr/local/share/gh-config-copy.sh
+check "config copy flag installed" test -f /usr/local/share/gh-copyconfig.flag
+
+if [ -f "${SOURCE_CONFIG}" ]; then
+    check "config copied" test -f "${TARGET_CONFIG}"
+else
+    check "config missing on host" test ! -f "${TARGET_CONFIG}"
+fi
+
+reportResults

--- a/test/gh/with_git_auth.sh
+++ b/test/gh/with_git_auth.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "git auth flag installed" test -f /usr/local/share/gh-git-auth.flag
+
+WORKSPACE_DIR="${WORKSPACE_FOLDER}"
+if [ -z "${WORKSPACE_DIR}" ] && [ -d "/workspaces" ]; then
+    for candidate in /workspaces/*; do
+        if [ -d "${candidate}/.git" ]; then
+            WORKSPACE_DIR="${candidate}"
+            break
+        fi
+    done
+fi
+if [ -z "${WORKSPACE_DIR}" ]; then
+    WORKSPACE_DIR=$(pwd)
+fi
+
+REMOTE_URL=$(git -C "${WORKSPACE_DIR}" remote get-url origin 2>/dev/null || true)
+if [ -z "${REMOTE_URL}" ]; then
+    echo "No origin remote found; skipping git auth assertions"
+    reportResults
+    exit 0
+fi
+
+case "${REMOTE_URL}" in
+    git@*|ssh://*)
+        HELPER=$(git config --global --get "credential.${REMOTE_URL}.helper" 2>/dev/null || true)
+        check "ssh remote not configured" test -z "${HELPER}"
+        ;;
+    *)
+        check "git auth configured" test "$(git config --global --get "credential.${REMOTE_URL}.helper")" = "!gh auth git-credential"
+        ;;
+esac
+
+reportResults


### PR DESCRIPTION
## Summary
- add a new `gh` Wolfi feature modeled after `glab`
- support optional host credential copy (`copyConfig`) and optional git credential helper setup (`useGitAuth`)
- add `gh` feature tests and include `gh` in CI scenario matrix

## Testing
- `devcontainer features test -f gh --skip-autogenerated --skip-duplicated .`

Closes #63
