### PR TITLE
Ensure common-utils adds non-root user to sudo group

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "common-utils",
     "id": "common-utils",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs common command line utilities, configures a non-root user, and optionally sets up Zsh on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/common-utils",
     "options": {

--- a/src/common-utils/install.sh
+++ b/src/common-utils/install.sh
@@ -136,6 +136,14 @@ else
 fi
 
 if [ "${USERNAME}" != "root" ]; then
+    if ! awk -F: '$1=="sudo" { found=1 } END { exit(found ? 0 : 1) }' /etc/group; then
+        echo "Creating sudo group..."
+        groupadd sudo
+    fi
+
+    echo "Adding ${USERNAME} to sudo group..."
+    usermod -aG sudo "${USERNAME}"
+
     echo "Configuring passwordless sudo for ${USERNAME}..."
     mkdir -p /etc/sudoers.d
     echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > "/etc/sudoers.d/${USERNAME}"

--- a/test/common-utils/custom_user.sh
+++ b/test/common-utils/custom_user.sh
@@ -7,6 +7,7 @@ source dev-container-features-test-lib
 check "custom user exists" id -u testuser
 check "custom user uid" bash -lc '[ "$(id -u testuser)" = "2001" ]'
 check "custom user gid" bash -lc '[ "$(id -g testuser)" = "2001" ]'
+check "custom user in sudo group" bash -lc "id -nG testuser | tr ' ' '\\n' | grep -qx sudo"
 check "sudoers file for custom user" test -f /etc/sudoers.d/testuser
 
 reportResults

--- a/test/common-utils/default.sh
+++ b/test/common-utils/default.sh
@@ -8,6 +8,7 @@ check "curl installed" command -v curl
 check "git installed" command -v git
 check "zsh installed" command -v zsh
 check "default user exists" id -u vscode
+check "default user in sudo group" bash -lc "id -nG vscode | tr ' ' '\\n' | grep -qx sudo"
 check "oh-my-zsh installed for vscode" test -d /home/vscode/.oh-my-zsh
 check "sudoers file for vscode" test -f /etc/sudoers.d/vscode
 


### PR DESCRIPTION
## Summary
- ensure common-utils creates the sudo group when missing and adds the configured non-root user to it
- keep existing passwordless sudoers drop-in behavior unchanged
- add tests for default and custom user scenarios to verify sudo group membership
- bump common-utils feature version to 1.0.1

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced non-root user setup with automatic group membership and passwordless permission configuration

* **Tests**
  * Added test verification for user group memberships

* **Chores**
  * Version bumped to 1.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->