### PR TITLE
Bump feature patch versions after postStart fallback merge

### DIFF
--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "claude",
     "id": "claude",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs Claude Code CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/claude",
     "options": {

--- a/src/cursor/devcontainer-feature.json
+++ b/src/cursor/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "cursor",
     "id": "cursor",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs Cursor Agent CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/cursor",
     "options": {

--- a/src/gh/devcontainer-feature.json
+++ b/src/gh/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "gh",
     "id": "gh",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs GitHub CLI (gh) on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/gh",
     "options": {

--- a/src/glab/devcontainer-feature.json
+++ b/src/glab/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "glab",
     "id": "glab",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs glab CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/glab",
     "options": {

--- a/src/opencode/devcontainer-feature.json
+++ b/src/opencode/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "opencode",
     "id": "opencode",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Installs opencode CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/opencode",
     "options": {


### PR DESCRIPTION
## Summary
- Bump patch versions for features updated in the merged postStart fallback work.
- Update versions to reflect published change history:
  - `opencode`: `1.4.1` -> `1.4.2`
  - `gh`: `1.0.1` -> `1.0.2`
  - `glab`: `1.0.1` -> `1.0.2`
  - `cursor`: `1.0.1` -> `1.0.2`
  - `claude`: `1.0.1` -> `1.0.2`

## Why
PR #69 merged the runtime fallback/install updates, but these manifest patch bumps were not included in `main`.
This follow-up keeps feature versions aligned with shipped behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated devcontainer feature versions: Claude, Cursor, GitHub CLI, and GitLab CLI features bumped to version 1.0.2; OpenCode feature bumped to version 1.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->