### PR TITLE
Update common-utils with iconv, bat, and neovim

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "common-utils",
     "id": "common-utils",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs common command line utilities, configures a non-root user, and optionally sets up Zsh on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/common-utils",
     "options": {

--- a/src/common-utils/install.sh
+++ b/src/common-utils/install.sh
@@ -37,6 +37,7 @@ echo "Installing common packages..."
 apk add --no-cache \
     bash \
     bash-completion \
+    bat \
     openssh-client \
     gnupg \
     procps \
@@ -52,6 +53,7 @@ apk add --no-cache \
     unzip \
     xz \
     zip \
+    neovim \
     nano \
     vim \
     less \
@@ -65,7 +67,13 @@ apk add --no-cache \
     grep \
     shadow \
     strace \
-    git
+    git \
+    gnu-libiconv
+
+if ! command -v iconv >/dev/null 2>&1 && command -v gnu-iconv >/dev/null 2>&1; then
+    mkdir -p /usr/local/bin
+    ln -sf /usr/bin/gnu-iconv /usr/local/bin/iconv
+fi
 
 if [ "${INSTALL_ZSH}" = "true" ]; then
     echo "Installing zsh..."

--- a/test/common-utils/default.sh
+++ b/test/common-utils/default.sh
@@ -6,6 +6,9 @@ source dev-container-features-test-lib
 
 check "curl installed" command -v curl
 check "git installed" command -v git
+check "iconv installed" command -v iconv
+check "bat installed" command -v bat
+check "nvim installed" command -v nvim
 check "zsh installed" command -v zsh
 check "default user exists" id -u vscode
 check "default user in sudo group" bash -lc "id -nG vscode | tr ' ' '\\n' | grep -qx sudo"


### PR DESCRIPTION
## Summary
- install `gnu-libiconv`, `bat`, and `neovim` in the common-utils package list
- create `/usr/local/bin/iconv` symlink to `gnu-iconv` when `iconv` is missing
- bump common-utils feature version to `1.0.2` and add default scenario checks for `iconv`, `bat`, and `nvim`

## Testing
- `sh -n src/common-utils/install.sh`
- `devcontainer features test -f common-utils --skip-autogenerated --skip-duplicated .`

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version updated to 1.0.2.
  * Added bat, neovim, and iconv utilities to the development environment.
  * Improved iconv compatibility with automatic fallback support for enhanced portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->