### PR TITLE
Align postStart copy hook generation across features

### DIFF
--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "claude",
     "id": "claude",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Installs Claude Code CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/claude",
     "options": {

--- a/src/claude/install.sh
+++ b/src/claude/install.sh
@@ -97,55 +97,62 @@ fi
 echo "Installing Claude Code settings copy hook"
 mkdir -p /usr/local/share
 
-cat << 'EOF' > /usr/local/share/claude-settings-copy.sh
+RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
+RESOLVED_TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
+    RESOLVED_TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${RESOLVED_TARGET_USER}" ] && id -u "${RESOLVED_TARGET_USER}" >/dev/null 2>&1; then
+    RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="${HOME}"
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] || [ -z "${RESOLVED_TARGET_HOME}" ] || [ "${RESOLVED_TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
+        RESOLVED_TARGET_USER="${FALLBACK_USER}"
+        RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+    fi
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] && [ -n "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_USER=$(awk -F: -v home="${RESOLVED_TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="/root"
+fi
+
+cat << EOF > /usr/local/share/claude-settings-copy.sh
 #!/bin/sh
 set -e
 
 SOURCE_SETTINGS="/tmp/claude-host-tmp/settings.json"
 FLAG_FILE="/usr/local/share/claude-copysettings.flag"
-TARGET_USER="${_REMOTE_USER:-}"
-TARGET_HOME=""
+TARGET_USER="${RESOLVED_TARGET_USER}"
+TARGET_HOME="${RESOLVED_TARGET_HOME}"
 
-if [ -n "${_REMOTE_USER_HOME:-}" ]; then
-    TARGET_HOME="${_REMOTE_USER_HOME}"
-elif [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-fi
+TARGET_DIR="\${CLAUDE_CONFIG_DIR:-\${TARGET_HOME}/.claude}"
+TARGET_SETTINGS="\${TARGET_DIR}/settings.json"
 
-if [ -z "${TARGET_HOME}" ]; then
-    TARGET_HOME="${HOME}"
-fi
+if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_SETTINGS}" ]; then
+    mkdir -p "\${TARGET_DIR}"
+    cp "\${SOURCE_SETTINGS}" "\${TARGET_SETTINGS}"
 
-if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
-    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
-    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
-        TARGET_USER="${FALLBACK_USER}"
-        TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-    fi
-fi
-
-if [ -z "${TARGET_USER}" ] && [ -n "${TARGET_HOME}" ]; then
-    TARGET_USER=$(awk -F: -v home="${TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
-fi
-
-TARGET_DIR="${CLAUDE_CONFIG_DIR:-${TARGET_HOME}/.claude}"
-TARGET_SETTINGS="${TARGET_DIR}/settings.json"
-
-if [ -f "${FLAG_FILE}" ] && [ -f "${SOURCE_SETTINGS}" ]; then
-    mkdir -p "${TARGET_DIR}"
-    cp "${SOURCE_SETTINGS}" "${TARGET_SETTINGS}"
-
-    if [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-        TARGET_GROUP=$(id -gn "${TARGET_USER}" 2>/dev/null || true)
-        if [ -n "${TARGET_GROUP}" ]; then
-            chown "${TARGET_USER}:${TARGET_GROUP}" "${TARGET_DIR}" "${TARGET_SETTINGS}"
+    if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=\$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "\${TARGET_GROUP}" ]; then
+            chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_SETTINGS}"
         else
-            chown "${TARGET_USER}" "${TARGET_DIR}" "${TARGET_SETTINGS}"
+            chown "\${TARGET_USER}" "\${TARGET_DIR}" "\${TARGET_SETTINGS}"
         fi
     fi
 
-    chmod 700 "${TARGET_DIR}"
-    chmod 600 "${TARGET_SETTINGS}"
+    chmod 700 "\${TARGET_DIR}"
+    chmod 600 "\${TARGET_SETTINGS}"
 fi
 
 EOF

--- a/src/cursor/devcontainer-feature.json
+++ b/src/cursor/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "cursor",
     "id": "cursor",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Installs Cursor Agent CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/cursor",
     "options": {

--- a/src/cursor/install.sh
+++ b/src/cursor/install.sh
@@ -94,55 +94,62 @@ echo "Cursor Agent installed successfully"
 echo "Installing Cursor auth copy hook"
 mkdir -p /usr/local/share
 
-cat << 'EOF' > /usr/local/share/cursor-auth-copy.sh
+RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
+RESOLVED_TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
+    RESOLVED_TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${RESOLVED_TARGET_USER}" ] && id -u "${RESOLVED_TARGET_USER}" >/dev/null 2>&1; then
+    RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="${HOME}"
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] || [ -z "${RESOLVED_TARGET_HOME}" ] || [ "${RESOLVED_TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
+        RESOLVED_TARGET_USER="${FALLBACK_USER}"
+        RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+    fi
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] && [ -n "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_USER=$(awk -F: -v home="${RESOLVED_TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="/root"
+fi
+
+cat << EOF > /usr/local/share/cursor-auth-copy.sh
 #!/bin/sh
 set -e
 
 SOURCE_AUTH="/tmp/cursor-host-tmp/auth.json"
 FLAG_FILE="/usr/local/share/cursor-copyauth.flag"
-TARGET_USER="${_REMOTE_USER:-}"
-TARGET_HOME=""
+TARGET_USER="${RESOLVED_TARGET_USER}"
+TARGET_HOME="${RESOLVED_TARGET_HOME}"
 
-if [ -n "${_REMOTE_USER_HOME:-}" ]; then
-    TARGET_HOME="${_REMOTE_USER_HOME}"
-elif [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-fi
+TARGET_AUTH="\${TARGET_HOME}/.config/cursor/auth.json"
 
-if [ -z "${TARGET_HOME}" ]; then
-    TARGET_HOME="${HOME}"
-fi
+if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_AUTH}" ]; then
+    TARGET_DIR=\$(dirname "\${TARGET_AUTH}")
+    mkdir -p "\${TARGET_DIR}"
+    cp "\${SOURCE_AUTH}" "\${TARGET_AUTH}"
 
-if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
-    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
-    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
-        TARGET_USER="${FALLBACK_USER}"
-        TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-    fi
-fi
-
-if [ -z "${TARGET_USER}" ] && [ -n "${TARGET_HOME}" ]; then
-    TARGET_USER=$(awk -F: -v home="${TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
-fi
-
-TARGET_AUTH="${TARGET_HOME}/.config/cursor/auth.json"
-
-if [ -f "${FLAG_FILE}" ] && [ -f "${SOURCE_AUTH}" ]; then
-    TARGET_DIR=$(dirname "${TARGET_AUTH}")
-    mkdir -p "${TARGET_DIR}"
-    cp "${SOURCE_AUTH}" "${TARGET_AUTH}"
-
-    if [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-        TARGET_GROUP=$(id -gn "${TARGET_USER}" 2>/dev/null || true)
-        if [ -n "${TARGET_GROUP}" ]; then
-            chown "${TARGET_USER}:${TARGET_GROUP}" "${TARGET_DIR}" "${TARGET_AUTH}"
+    if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=\$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "\${TARGET_GROUP}" ]; then
+            chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_AUTH}"
         else
-            chown "${TARGET_USER}" "${TARGET_DIR}" "${TARGET_AUTH}"
+            chown "\${TARGET_USER}" "\${TARGET_DIR}" "\${TARGET_AUTH}"
         fi
     fi
 
-    chmod 700 "${TARGET_DIR}"
-    chmod 600 "${TARGET_AUTH}"
+    chmod 700 "\${TARGET_DIR}"
+    chmod 600 "\${TARGET_AUTH}"
 fi
 
 EOF

--- a/src/gh/devcontainer-feature.json
+++ b/src/gh/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "gh",
     "id": "gh",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Installs GitHub CLI (gh) on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/gh",
     "options": {

--- a/src/gh/install.sh
+++ b/src/gh/install.sh
@@ -26,90 +26,97 @@ fi
 echo "Installing gh config copy hook"
 mkdir -p /usr/local/share
 
-cat << 'EOF' > /usr/local/share/gh-config-copy.sh
+RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
+RESOLVED_TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
+    RESOLVED_TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${RESOLVED_TARGET_USER}" ] && id -u "${RESOLVED_TARGET_USER}" >/dev/null 2>&1; then
+    RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="${HOME}"
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] || [ -z "${RESOLVED_TARGET_HOME}" ] || [ "${RESOLVED_TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
+        RESOLVED_TARGET_USER="${FALLBACK_USER}"
+        RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+    fi
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] && [ -n "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_USER=$(awk -F: -v home="${RESOLVED_TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="/root"
+fi
+
+cat << EOF > /usr/local/share/gh-config-copy.sh
 #!/bin/sh
 set -e
 
 SOURCE_CONFIG="/tmp/gh-host-tmp/hosts.yml"
 FLAG_FILE="/usr/local/share/gh-copyconfig.flag"
 AUTH_FLAG_FILE="/usr/local/share/gh-git-auth.flag"
-TARGET_USER="${_REMOTE_USER:-}"
-TARGET_HOME=""
+TARGET_USER="${RESOLVED_TARGET_USER}"
+TARGET_HOME="${RESOLVED_TARGET_HOME}"
 
-if [ -n "${_REMOTE_USER_HOME:-}" ]; then
-    TARGET_HOME="${_REMOTE_USER_HOME}"
-elif [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-fi
+TARGET_CONFIG="\${TARGET_HOME}/.config/gh/hosts.yml"
 
-if [ -z "${TARGET_HOME}" ]; then
-    TARGET_HOME="${HOME}"
-fi
+if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_CONFIG}" ]; then
+    TARGET_DIR=\$(dirname "\${TARGET_CONFIG}")
+    mkdir -p "\${TARGET_DIR}"
+    cp "\${SOURCE_CONFIG}" "\${TARGET_CONFIG}"
 
-if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
-    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
-    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
-        TARGET_USER="${FALLBACK_USER}"
-        TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-    fi
-fi
-
-if [ -z "${TARGET_USER}" ] && [ -n "${TARGET_HOME}" ]; then
-    TARGET_USER=$(awk -F: -v home="${TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
-fi
-
-TARGET_CONFIG="${TARGET_HOME}/.config/gh/hosts.yml"
-
-if [ -f "${FLAG_FILE}" ] && [ -f "${SOURCE_CONFIG}" ]; then
-    TARGET_DIR=$(dirname "${TARGET_CONFIG}")
-    mkdir -p "${TARGET_DIR}"
-    cp "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
-
-    if [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-        TARGET_GROUP=$(id -gn "${TARGET_USER}" 2>/dev/null || true)
-        if [ -n "${TARGET_GROUP}" ]; then
-            chown "${TARGET_USER}:${TARGET_GROUP}" "${TARGET_DIR}" "${TARGET_CONFIG}"
+    if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=\$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "\${TARGET_GROUP}" ]; then
+            chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
         else
-            chown "${TARGET_USER}" "${TARGET_DIR}" "${TARGET_CONFIG}"
+            chown "\${TARGET_USER}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
         fi
     fi
 
-    chmod 700 "${TARGET_DIR}"
-    chmod 600 "${TARGET_CONFIG}"
+    chmod 700 "\${TARGET_DIR}"
+    chmod 600 "\${TARGET_CONFIG}"
 fi
 
-if [ -f "${AUTH_FLAG_FILE}" ]; then
+if [ -f "\${AUTH_FLAG_FILE}" ]; then
     if command -v git >/dev/null 2>&1; then
-        WORKSPACE_DIR="${WORKSPACE_FOLDER:-}"
-        if [ -z "${WORKSPACE_DIR}" ]; then
-            CURRENT_DIR=$(pwd)
-            if git -C "${CURRENT_DIR}" rev-parse --show-toplevel >/dev/null 2>&1; then
-                WORKSPACE_DIR=$(git -C "${CURRENT_DIR}" rev-parse --show-toplevel)
+        WORKSPACE_DIR="\${WORKSPACE_FOLDER:-}"
+        if [ -z "\${WORKSPACE_DIR}" ]; then
+            CURRENT_DIR=\$(pwd)
+            if git -C "\${CURRENT_DIR}" rev-parse --show-toplevel >/dev/null 2>&1; then
+                WORKSPACE_DIR=\$(git -C "\${CURRENT_DIR}" rev-parse --show-toplevel)
             fi
         fi
-        if [ -z "${WORKSPACE_DIR}" ] && [ -d "/workspaces" ]; then
+        if [ -z "\${WORKSPACE_DIR}" ] && [ -d "/workspaces" ]; then
             for candidate in /workspaces/*; do
-                if [ -d "${candidate}" ] && git -C "${candidate}" rev-parse --show-toplevel >/dev/null 2>&1; then
-                    WORKSPACE_DIR=$(git -C "${candidate}" rev-parse --show-toplevel)
+                if [ -d "\${candidate}" ] && git -C "\${candidate}" rev-parse --show-toplevel >/dev/null 2>&1; then
+                    WORKSPACE_DIR=\$(git -C "\${candidate}" rev-parse --show-toplevel)
                     break
                 fi
             done
         fi
 
-        if [ -z "${WORKSPACE_DIR}" ]; then
+        if [ -z "\${WORKSPACE_DIR}" ]; then
             echo "Workspace not found; skipping gh git auth configuration"
         else
-            REMOTE_URL=$(git -C "${WORKSPACE_DIR}" remote get-url origin 2>/dev/null || true)
-            if [ -z "${REMOTE_URL}" ]; then
+            REMOTE_URL=\$(git -C "\${WORKSPACE_DIR}" remote get-url origin 2>/dev/null || true)
+            if [ -z "\${REMOTE_URL}" ]; then
                 echo "No origin remote found; skipping gh git auth configuration"
             else
-                case "${REMOTE_URL}" in
+                case "\${REMOTE_URL}" in
                     git@*|ssh://*)
-                        echo "SSH remote detected (${REMOTE_URL}); skipping gh git auth configuration"
+                        echo "SSH remote detected (\${REMOTE_URL}); skipping gh git auth configuration"
                         ;;
                     *)
-                        git config --global "credential.${REMOTE_URL}.helper" "!gh auth git-credential"
-                        echo "Configured gh git auth for ${REMOTE_URL}"
+                        git config --global "credential.\${REMOTE_URL}.helper" "!gh auth git-credential"
+                        echo "Configured gh git auth for \${REMOTE_URL}"
                         ;;
                 esac
             fi

--- a/src/glab/devcontainer-feature.json
+++ b/src/glab/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "glab",
     "id": "glab",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Installs glab CLI on Wolfi base images.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/glab",
     "options": {

--- a/src/glab/install.sh
+++ b/src/glab/install.sh
@@ -26,90 +26,97 @@ fi
 echo "Installing glab config copy hook"
 mkdir -p /usr/local/share
 
-cat << 'EOF' > /usr/local/share/glab-config-copy.sh
+RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
+RESOLVED_TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
+    RESOLVED_TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${RESOLVED_TARGET_USER}" ] && id -u "${RESOLVED_TARGET_USER}" >/dev/null 2>&1; then
+    RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="${HOME}"
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] || [ -z "${RESOLVED_TARGET_HOME}" ] || [ "${RESOLVED_TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
+        RESOLVED_TARGET_USER="${FALLBACK_USER}"
+        RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+    fi
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] && [ -n "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_USER=$(awk -F: -v home="${RESOLVED_TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="/root"
+fi
+
+cat << EOF > /usr/local/share/glab-config-copy.sh
 #!/bin/sh
 set -e
 
 SOURCE_CONFIG="/tmp/glab-host-tmp/config.yml"
 FLAG_FILE="/usr/local/share/glab-copyconfig.flag"
 AUTH_FLAG_FILE="/usr/local/share/glab-git-auth.flag"
-TARGET_USER="${_REMOTE_USER:-}"
-TARGET_HOME=""
+TARGET_USER="${RESOLVED_TARGET_USER}"
+TARGET_HOME="${RESOLVED_TARGET_HOME}"
 
-if [ -n "${_REMOTE_USER_HOME:-}" ]; then
-    TARGET_HOME="${_REMOTE_USER_HOME}"
-elif [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-fi
+TARGET_CONFIG="\${TARGET_HOME}/.config/glab-cli/config.yml"
 
-if [ -z "${TARGET_HOME}" ]; then
-    TARGET_HOME="${HOME}"
-fi
+if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_CONFIG}" ]; then
+    TARGET_DIR=\$(dirname "\${TARGET_CONFIG}")
+    mkdir -p "\${TARGET_DIR}"
+    cp "\${SOURCE_CONFIG}" "\${TARGET_CONFIG}"
 
-if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
-    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
-    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
-        TARGET_USER="${FALLBACK_USER}"
-        TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
-    fi
-fi
-
-if [ -z "${TARGET_USER}" ] && [ -n "${TARGET_HOME}" ]; then
-    TARGET_USER=$(awk -F: -v home="${TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
-fi
-
-TARGET_CONFIG="${TARGET_HOME}/.config/glab-cli/config.yml"
-
-if [ -f "${FLAG_FILE}" ] && [ -f "${SOURCE_CONFIG}" ]; then
-    TARGET_DIR=$(dirname "${TARGET_CONFIG}")
-    mkdir -p "${TARGET_DIR}"
-    cp "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
-
-    if [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
-        TARGET_GROUP=$(id -gn "${TARGET_USER}" 2>/dev/null || true)
-        if [ -n "${TARGET_GROUP}" ]; then
-            chown "${TARGET_USER}:${TARGET_GROUP}" "${TARGET_DIR}" "${TARGET_CONFIG}"
+    if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=\$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "\${TARGET_GROUP}" ]; then
+            chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
         else
-            chown "${TARGET_USER}" "${TARGET_DIR}" "${TARGET_CONFIG}"
+            chown "\${TARGET_USER}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
         fi
     fi
 
-    chmod 700 "${TARGET_DIR}"
-    chmod 600 "${TARGET_CONFIG}"
+    chmod 700 "\${TARGET_DIR}"
+    chmod 600 "\${TARGET_CONFIG}"
 fi
 
-if [ -f "${AUTH_FLAG_FILE}" ]; then
+if [ -f "\${AUTH_FLAG_FILE}" ]; then
     if command -v git >/dev/null 2>&1; then
-        WORKSPACE_DIR="${WORKSPACE_FOLDER:-}"
-        if [ -z "${WORKSPACE_DIR}" ]; then
-            CURRENT_DIR=$(pwd)
-            if git -C "${CURRENT_DIR}" rev-parse --show-toplevel >/dev/null 2>&1; then
-                WORKSPACE_DIR=$(git -C "${CURRENT_DIR}" rev-parse --show-toplevel)
+        WORKSPACE_DIR="\${WORKSPACE_FOLDER:-}"
+        if [ -z "\${WORKSPACE_DIR}" ]; then
+            CURRENT_DIR=\$(pwd)
+            if git -C "\${CURRENT_DIR}" rev-parse --show-toplevel >/dev/null 2>&1; then
+                WORKSPACE_DIR=\$(git -C "\${CURRENT_DIR}" rev-parse --show-toplevel)
             fi
         fi
-        if [ -z "${WORKSPACE_DIR}" ] && [ -d "/workspaces" ]; then
+        if [ -z "\${WORKSPACE_DIR}" ] && [ -d "/workspaces" ]; then
             for candidate in /workspaces/*; do
-                if [ -d "${candidate}" ] && git -C "${candidate}" rev-parse --show-toplevel >/dev/null 2>&1; then
-                    WORKSPACE_DIR=$(git -C "${candidate}" rev-parse --show-toplevel)
+                if [ -d "\${candidate}" ] && git -C "\${candidate}" rev-parse --show-toplevel >/dev/null 2>&1; then
+                    WORKSPACE_DIR=\$(git -C "\${candidate}" rev-parse --show-toplevel)
                     break
                 fi
             done
         fi
 
-        if [ -z "${WORKSPACE_DIR}" ]; then
+        if [ -z "\${WORKSPACE_DIR}" ]; then
             echo "Workspace not found; skipping glab git auth configuration"
         else
-            REMOTE_URL=$(git -C "${WORKSPACE_DIR}" remote get-url origin 2>/dev/null || true)
-            if [ -z "${REMOTE_URL}" ]; then
+            REMOTE_URL=\$(git -C "\${WORKSPACE_DIR}" remote get-url origin 2>/dev/null || true)
+            if [ -z "\${REMOTE_URL}" ]; then
                 echo "No origin remote found; skipping glab git auth configuration"
             else
-                case "${REMOTE_URL}" in
+                case "\${REMOTE_URL}" in
                     git@*|ssh://*)
-                        echo "SSH remote detected (${REMOTE_URL}); skipping glab git auth configuration"
+                        echo "SSH remote detected (\${REMOTE_URL}); skipping glab git auth configuration"
                         ;;
                     *)
-                        git config --global "credential.${REMOTE_URL}.helper" "!glab auth git-credential"
-                        echo "Configured glab git auth for ${REMOTE_URL}"
+                        git config --global "credential.\${REMOTE_URL}.helper" "!glab auth git-credential"
+                        echo "Configured glab git auth for \${REMOTE_URL}"
                         ;;
                 esac
             fi

--- a/test/cursor/with_auth.sh
+++ b/test/cursor/with_auth.sh
@@ -4,13 +4,30 @@ set -e
 
 source dev-container-features-test-lib
 
-TARGET_HOME="${HOME}"
-if [ -z "${TARGET_HOME}" ]; then
+TARGET_USER="${_REMOTE_USER:-}"
+TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
     TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${TARGET_USER}" ]; then
+    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
 fi
+
 if [ -z "${TARGET_HOME}" ]; then
-    TARGET_HOME=$(grep -E "^${_REMOTE_USER}:" /etc/passwd | cut -d: -f6)
+    TARGET_HOME="${HOME:-}"
 fi
+
+if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ]; then
+        TARGET_USER="${FALLBACK_USER}"
+        FALLBACK_HOME=$(awk -F: -v user="${FALLBACK_USER}" '$1==user{print $6}' /etc/passwd)
+        if [ -n "${FALLBACK_HOME}" ]; then
+            TARGET_HOME="${FALLBACK_HOME}"
+        fi
+    fi
+fi
+
 if [ -z "${TARGET_HOME}" ]; then
     TARGET_HOME="/root"
 fi

--- a/test/gh/with_config.sh
+++ b/test/gh/with_config.sh
@@ -4,15 +4,30 @@ set -e
 
 source dev-container-features-test-lib
 
-TARGET_HOME="${HOME}"
-if [ -z "${TARGET_HOME}" ]; then
+TARGET_USER="${_REMOTE_USER:-}"
+TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
     TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${TARGET_USER}" ]; then
+    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
 fi
+
 if [ -z "${TARGET_HOME}" ]; then
-    if [ -n "${_REMOTE_USER:-}" ]; then
-        TARGET_HOME=$(grep -E "^${_REMOTE_USER}:" /etc/passwd | cut -d: -f6)
+    TARGET_HOME="${HOME:-}"
+fi
+
+if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ]; then
+        TARGET_USER="${FALLBACK_USER}"
+        FALLBACK_HOME=$(awk -F: -v user="${FALLBACK_USER}" '$1==user{print $6}' /etc/passwd)
+        if [ -n "${FALLBACK_HOME}" ]; then
+            TARGET_HOME="${FALLBACK_HOME}"
+        fi
     fi
 fi
+
 if [ -z "${TARGET_HOME}" ]; then
     TARGET_HOME="/root"
 fi

--- a/test/glab/with_config.sh
+++ b/test/glab/with_config.sh
@@ -4,15 +4,30 @@ set -e
 
 source dev-container-features-test-lib
 
-TARGET_HOME="${HOME}"
-if [ -z "${TARGET_HOME}" ]; then
+TARGET_USER="${_REMOTE_USER:-}"
+TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
     TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${TARGET_USER}" ]; then
+    TARGET_HOME=$(awk -F: -v user="${TARGET_USER}" '$1==user{print $6}' /etc/passwd)
 fi
+
 if [ -z "${TARGET_HOME}" ]; then
-    if [ -n "${_REMOTE_USER:-}" ]; then
-        TARGET_HOME=$(grep -E "^${_REMOTE_USER}:" /etc/passwd | cut -d: -f6)
+    TARGET_HOME="${HOME:-}"
+fi
+
+if [ -z "${TARGET_USER}" ] || [ -z "${TARGET_HOME}" ] || [ "${TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ]; then
+        TARGET_USER="${FALLBACK_USER}"
+        FALLBACK_HOME=$(awk -F: -v user="${FALLBACK_USER}" '$1==user{print $6}' /etc/passwd)
+        if [ -n "${FALLBACK_HOME}" ]; then
+            TARGET_HOME="${FALLBACK_HOME}"
+        fi
     fi
 fi
+
 if [ -z "${TARGET_HOME}" ]; then
     TARGET_HOME="/root"
 fi


### PR DESCRIPTION
## Summary
- align claude, cursor, gh, and glab install scripts with the opencode pattern by resolving target user/home during install and baking values into generated postStart hook scripts
- keep feature behavior the same while preserving copy and git-auth hook logic, and bump affected feature versions from 1.0.2 to 1.0.3
- update scenario tests for cursor, gh, and glab to assert copied files in the same resolved target home path used by the new hook generation flow

## Testing
- devcontainer features test -f cursor -f gh -f glab --skip-autogenerated --skip-duplicated .

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.3 across all features.

* **Bug Fixes**
  * Enhanced target user and home directory resolution logic with improved fallback mechanisms to ensure robust configuration handling across different user environments and system setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->