### PR TITLE
Add Wolfi-native docker-in-docker feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
           - bash
           - chromium
           - common-utils
+          - docker-in-docker
           - docker-outside-of-docker
           - claude
           - cursor

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The following features are available:
 - [bash](./src/bash/README.md) - Installs bash and common shell utilities on Wolfi base images
 - [chromium](./src/chromium/README.md) - Installs Chromium browser on Wolfi base images
 - [common-utils](./src/common-utils/README.md) - Installs common command line utilities, configures users, and optionally sets up Zsh on Wolfi base images (lean Wolfi-native variant)
-- [docker-outside-of-docker](./src/docker-outside-of-docker/README.md) - Enables Docker-in-Docker functionality for development containers
+- [docker-in-docker](./src/docker-in-docker/README.md) - Runs a Docker daemon inside Wolfi-based development containers
+- [docker-outside-of-docker](./src/docker-outside-of-docker/README.md) - Reuses the host Docker socket from inside development containers
 - [gh](./src/gh/README.md) - Installs GitHub CLI (gh) on Wolfi base images
 - [node](./src/node/README.md) - Installs Node.js and common Node.js utilities on Wolfi base images
 - [opencode](./src/opencode/README.md) - Installs opencode CLI on Wolfi base images

--- a/src/docker-in-docker/README.md
+++ b/src/docker-in-docker/README.md
@@ -1,0 +1,34 @@
+
+# docker-in-docker (docker-in-docker)
+
+Run a Docker daemon inside Wolfi-based development containers using Wolfi packages.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/docker-in-docker:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| installDockerBuildx | Install Docker Buildx. | boolean | true |
+| dockerDashComposeVersion | Default version of Docker Compose (v2 or none). | string | v2 |
+| azureDnsAutoDetection | Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure. | boolean | true |
+| dockerDefaultAddressPool | Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24 | string |  |
+| disableIp6tables | Disable ip6tables for the inner Docker daemon. | boolean | false |
+
+## Customizations
+
+### VS Code Extensions
+
+- `ms-azuretools.vscode-docker`
+
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/docker-in-docker/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,0 +1,57 @@
+{
+    "name": "docker-in-docker",
+    "id": "docker-in-docker",
+    "version": "1.0.0",
+    "description": "Run a Docker daemon inside Wolfi-based development containers using Wolfi packages.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/docker-in-docker",
+    "options": {
+        "installDockerBuildx": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install Docker Buildx."
+        },
+        "dockerDashComposeVersion": {
+            "type": "string",
+            "enum": [
+                "none",
+                "v2"
+            ],
+            "default": "v2",
+            "description": "Default version of Docker Compose (v2 or none)."
+        },
+        "azureDnsAutoDetection": {
+            "type": "boolean",
+            "default": true,
+            "description": "Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure."
+        },
+        "dockerDefaultAddressPool": {
+            "type": "string",
+            "default": "",
+            "description": "Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24"
+        },
+        "disableIp6tables": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable ip6tables for the inner Docker daemon."
+        }
+    },
+    "entrypoint": "/usr/local/share/docker-in-docker-init.sh",
+    "privileged": true,
+    "containerEnv": {
+        "DOCKER_BUILDKIT": "1"
+    },
+    "mounts": [
+        {
+            "source": "dind-var-lib-docker-${devcontainerId}",
+            "target": "/var/lib/docker",
+            "type": "volume"
+        }
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
+}

--- a/src/docker-in-docker/dockerd-entrypoint.sh
+++ b/src/docker-in-docker/dockerd-entrypoint.sh
@@ -105,22 +105,10 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ]; then
 		_tls_generate_certs "$DOCKER_TLS_CERTDIR"
-		set -- dockerd \
-			--host="$dockerSocket" \
-			--host=tcp://0.0.0.0:2376 \
-			--tlsverify \
-			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
-			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
-			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
-			"$@"
-		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2376:2376/tcp"
-	else
-		set -- dockerd \
-			--host="$dockerSocket" \
-			--host=tcp://0.0.0.0:2375 \
-			"$@"
-		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"
 	fi
+	set -- dockerd \
+		--host="$dockerSocket" \
+		"$@"
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/src/docker-in-docker/dockerd-entrypoint.sh
+++ b/src/docker-in-docker/dockerd-entrypoint.sh
@@ -1,0 +1,203 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4096
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed 's/,$//'
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! -s "$dir/ca/key.pem" ]; then
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+		return 0
+	fi
+
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' \
+			-x509 \
+			-days "$certValidDays" \
+			-addext keyUsage=critical,digitalSignature,keyCertSign
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			extendedKeyUsage = serverAuth
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem"
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	uid="$(id -u)"
+	if [ "$uid" = '0' ]; then
+		dockerSocket='unix:///var/run/docker.sock'
+	else
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
+	fi
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
+
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ]; then
+		_tls_generate_certs "$DOCKER_TLS_CERTDIR"
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2376:2376/tcp"
+	else
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"
+	fi
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	find /run /var/run -iname 'docker*.pid' -delete || :
+
+	set -- docker-init -- "$@"
+
+	iptablesLegacy=
+	if [ -n "${DOCKER_IPTABLES_LEGACY+x}" ]; then
+		iptablesLegacy="$DOCKER_IPTABLES_LEGACY"
+		if [ -n "$iptablesLegacy" ]; then
+			modprobe ip_tables || :
+			modprobe ip6_tables || :
+		else
+			modprobe nf_tables || :
+		fi
+	elif (
+		for f in /proc/net/ip_tables_names /proc/net/ip6_tables_names /proc/net/arp_tables_names; do
+			if b="$(cat "$f")" && [ -n "$b" ]; then
+				exit 0
+			fi
+		done
+		exit 1
+	); then
+		iptablesLegacy=1
+	elif ! iptables -nL > /dev/null 2>&1; then
+		modprobe nf_tables || :
+		if ! iptables -nL > /dev/null 2>&1; then
+			modprobe ip_tables || :
+			modprobe ip6_tables || :
+			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
+				iptablesLegacy=1
+			fi
+		fi
+	fi
+	if [ -n "$iptablesLegacy" ]; then
+		export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+	fi
+	iptables --version
+
+	uid="$(id -u)"
+	if [ "$uid" != '0' ]; then
+		if ! command -v rootlesskit > /dev/null; then
+			echo >&2 "error: attempting to run rootless dockerd but missing 'rootlesskit'"
+			exit 1
+		fi
+		user="$(id -un 2>/dev/null || :)"
+		if ! grep -qE "^($uid${user:+|$user}):" /etc/subuid || ! grep -qE "^($uid${user:+|$user}):" /etc/subgid; then
+			echo >&2 "error: attempting to run rootless dockerd but missing necessary entries in /etc/subuid and/or /etc/subgid for $uid"
+			exit 1
+		fi
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		export XDG_RUNTIME_DIR
+		if ! mkdir -p "$XDG_RUNTIME_DIR" || [ ! -w "$XDG_RUNTIME_DIR" ] || ! mkdir -p "$HOME/.local/share/docker" || [ ! -w "$HOME/.local/share/docker" ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need writable HOME ($HOME) and XDG_RUNTIME_DIR ($XDG_RUNTIME_DIR) for user $uid"
+			exit 1
+		fi
+		if [ -f /proc/sys/kernel/unprivileged_userns_clone ] && unprivClone="$(cat /proc/sys/kernel/unprivileged_userns_clone)" && [ "$unprivClone" != '1' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'kernel.unprivileged_userns_clone' set to 1"
+			exit 1
+		fi
+		if [ -f /proc/sys/user/max_user_namespaces ] && maxUserns="$(cat /proc/sys/user/max_user_namespaces)" && [ "$maxUserns" = '0' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'user.max_user_namespaces' set to a sufficiently large value"
+			exit 1
+		fi
+		exec rootlesskit \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--disable-host-loopback \
+			--port-driver=builtin \
+			--copy-up=/etc \
+			--copy-up=/run \
+			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+			"$@"
+	elif [ -x '/usr/local/bin/dind' ]; then
+		set -- '/usr/local/bin/dind' "$@"
+	fi
+fi
+
+exec "$@"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -20,24 +20,46 @@ validate_bool() {
     fi
 }
 
+validate_address_pool() {
+    VALUE="$1"
+
+    case "${VALUE}" in
+        "")
+            ;;
+        *[!A-Za-z0-9=,./:-]*)
+            echo "dockerDefaultAddressPool contains unsupported characters."
+            exit 1
+            ;;
+    esac
+}
+
 resolve_username() {
     CANDIDATE="$1"
 
     if [ -z "${CANDIDATE}" ] || [ "${CANDIDATE}" = "auto" ] || [ "${CANDIDATE}" = "automatic" ]; then
-        if [ -n "${_REMOTE_USER}" ] && [ "${_REMOTE_USER}" != "root" ] && [ "${_REMOTE_USER}" != "0" ]; then
-            echo "${_REMOTE_USER}"
+        CANDIDATE="${_REMOTE_USER:-}"
+
+        case "${CANDIDATE}" in
+            ''|root|0)
+                CANDIDATE=""
+                ;;
+            *[!0-9]*)
+                echo "${CANDIDATE}"
+                return
+                ;;
+        esac
+
+        if [ -z "${CANDIDATE}" ]; then
+            for CURRENT_USER in devcontainer vscode node codespace; do
+                if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
+                    echo "${CURRENT_USER}"
+                    return
+                fi
+            done
+
+            echo "vscode"
             return
         fi
-
-        for CURRENT_USER in devcontainer vscode node codespace; do
-            if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-                echo "${CURRENT_USER}"
-                return
-            fi
-        done
-
-        echo "vscode"
-        return
     fi
 
     if [ "${CANDIDATE}" = "none" ] || [ "${CANDIDATE}" = "root" ] || [ "${CANDIDATE}" = "0" ]; then
@@ -87,6 +109,7 @@ ensure_user() {
 validate_bool "${INSTALL_DOCKER_BUILDX}" "installDockerBuildx"
 validate_bool "${AZURE_DNS_AUTO_DETECTION}" "azureDnsAutoDetection"
 validate_bool "${DISABLE_IP6_TABLES}" "disableIp6tables"
+validate_address_pool "${DOCKER_DEFAULT_ADDRESS_POOL}"
 
 case "${DOCKER_DASH_COMPOSE_VERSION}" in
     none|v2)
@@ -116,6 +139,12 @@ fi
 
 echo "Installing packages: ${PACKAGES}"
 apk add --no-cache ${PACKAGES}
+
+DIND_BIN="$(command -v dind || true)"
+if [ -z "${DIND_BIN}" ]; then
+    echo "Failed to locate dind after package installation."
+    exit 1
+fi
 
 ensure_user
 
@@ -156,6 +185,7 @@ set -e
 AZURE_DNS_AUTO_DETECTION='${AZURE_DNS_AUTO_DETECTION}'
 DOCKER_DEFAULT_ADDRESS_POOL='${DOCKER_DEFAULT_ADDRESS_POOL}'
 DOCKER_DEFAULT_IP6_TABLES='${DOCKER_DEFAULT_IP6_TABLES}'
+DIND_BIN='${DIND_BIN}'
 EOF
 
 cat >> "${INIT_SCRIPT}" <<'EOF'
@@ -168,27 +198,34 @@ sudo_if() {
 }
 
 start_dockerd() {
+    set +e
+    sudo_if find /run /var/run -iname 'docker*.pid' -delete
+    sudo_if find /run /var/run -iname 'container*.pid' -delete
+    set -e
+
+    set -- "${DIND_BIN}" /usr/local/share/docker-in-docker/dockerd-entrypoint.sh dockerd
+
     if grep -qi 'internal.cloudapp.net' /etc/resolv.conf 2>/dev/null && [ "${AZURE_DNS_AUTO_DETECTION}" = "true" ]; then
         echo "Setting dockerd Azure DNS."
-        CUSTOMDNS="--dns 168.63.129.16"
+        set -- "$@" --dns 168.63.129.16
     else
         echo "Not setting dockerd DNS manually."
-        CUSTOMDNS=""
     fi
 
     if [ -n "${DOCKER_DEFAULT_ADDRESS_POOL}" ]; then
-        DEFAULT_ADDRESS_POOL="--default-address-pool ${DOCKER_DEFAULT_ADDRESS_POOL}"
-    else
-        DEFAULT_ADDRESS_POOL=""
+        set -- "$@" "--default-address-pool=${DOCKER_DEFAULT_ADDRESS_POOL}"
     fi
 
-    START_COMMAND="find /run /var/run -iname 'docker*.pid' -delete || :; find /run /var/run -iname 'container*.pid' -delete || :; /usr/bin/dind /usr/local/share/docker-in-docker/dockerd-entrypoint.sh dockerd ${CUSTOMDNS} ${DEFAULT_ADDRESS_POOL} ${DOCKER_DEFAULT_IP6_TABLES} > /tmp/dockerd.log 2>&1 &"
+    if [ -n "${DOCKER_DEFAULT_IP6_TABLES}" ]; then
+        set -- "$@" "${DOCKER_DEFAULT_IP6_TABLES}"
+    fi
 
     if [ "$(id -u)" -ne 0 ]; then
-        sudo /bin/sh -c "${START_COMMAND}"
-    else
-        /bin/sh -c "${START_COMMAND}"
+        sudo "$@" > /tmp/dockerd.log 2>&1 &
+        return
     fi
+
+    "$@" > /tmp/dockerd.log 2>&1 &
 }
 
 retry_docker_start_count=0

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -1,0 +1,236 @@
+#!/bin/sh
+set -e
+
+INSTALL_DOCKER_BUILDX=${INSTALLDOCKERBUILDX:-"true"}
+DOCKER_DASH_COMPOSE_VERSION=${DOCKERDASHCOMPOSEVERSION:-"v2"}
+AZURE_DNS_AUTO_DETECTION=${AZUREDNSAUTODETECTION:-"true"}
+DOCKER_DEFAULT_ADDRESS_POOL=${DOCKERDEFAULTADDRESSPOOL:-""}
+DISABLE_IP6_TABLES=${DISABLEIP6TABLES:-"false"}
+USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+DOCKER_MAJOR="29"
+INIT_SCRIPT="/usr/local/share/docker-in-docker-init.sh"
+
+validate_bool() {
+    VALUE="$1"
+    NAME="$2"
+
+    if [ "${VALUE}" != "true" ] && [ "${VALUE}" != "false" ]; then
+        echo "${NAME} must be 'true' or 'false'. Got '${VALUE}'."
+        exit 1
+    fi
+}
+
+resolve_username() {
+    CANDIDATE="$1"
+
+    if [ -z "${CANDIDATE}" ] || [ "${CANDIDATE}" = "auto" ] || [ "${CANDIDATE}" = "automatic" ]; then
+        if [ -n "${_REMOTE_USER}" ] && [ "${_REMOTE_USER}" != "root" ] && [ "${_REMOTE_USER}" != "0" ]; then
+            echo "${_REMOTE_USER}"
+            return
+        fi
+
+        for CURRENT_USER in devcontainer vscode node codespace; do
+            if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
+                echo "${CURRENT_USER}"
+                return
+            fi
+        done
+
+        echo "vscode"
+        return
+    fi
+
+    if [ "${CANDIDATE}" = "none" ] || [ "${CANDIDATE}" = "root" ] || [ "${CANDIDATE}" = "0" ]; then
+        echo "root"
+        return
+    fi
+
+    case "${CANDIDATE}" in
+        ''|*[!0-9]*)
+            echo "${CANDIDATE}"
+            return
+            ;;
+        *)
+            RESOLVED="$(getent passwd "${CANDIDATE}" | cut -d: -f1)"
+            if [ -n "${RESOLVED}" ]; then
+                echo "${RESOLVED}"
+                return
+            fi
+            echo "root"
+            return
+            ;;
+    esac
+}
+
+ensure_user() {
+    if [ "${FEATURE_USER}" = "root" ]; then
+        return
+    fi
+
+    USER_SHELL="/bin/sh"
+    if [ -x /bin/bash ]; then
+        USER_SHELL="/bin/bash"
+    fi
+
+    if ! id -u "${FEATURE_USER}" >/dev/null 2>&1; then
+        echo "(*) Creating missing user '${FEATURE_USER}'..."
+        if ! grep -qE "^${FEATURE_USER}:" /etc/group; then
+            addgroup "${FEATURE_USER}"
+        fi
+        adduser -D -h "/home/${FEATURE_USER}" -s "${USER_SHELL}" -G "${FEATURE_USER}" "${FEATURE_USER}"
+    fi
+
+    mkdir -p "/home/${FEATURE_USER}"
+    chown -R "${FEATURE_USER}:$(id -gn "${FEATURE_USER}")" "/home/${FEATURE_USER}"
+}
+
+validate_bool "${INSTALL_DOCKER_BUILDX}" "installDockerBuildx"
+validate_bool "${AZURE_DNS_AUTO_DETECTION}" "azureDnsAutoDetection"
+validate_bool "${DISABLE_IP6_TABLES}" "disableIp6tables"
+
+case "${DOCKER_DASH_COMPOSE_VERSION}" in
+    none|v2)
+        ;;
+    *)
+        echo "dockerDashComposeVersion must be 'v2' or 'none'. Got '${DOCKER_DASH_COMPOSE_VERSION}'."
+        exit 1
+        ;;
+esac
+
+FEATURE_USER="$(resolve_username "${USERNAME}")"
+
+echo "Activating feature 'docker-in-docker'"
+echo "Using user '${FEATURE_USER}' for docker-in-docker setup"
+
+apk update
+
+PACKAGES="docker-cli dockerd-${DOCKER_MAJOR} docker-init-${DOCKER_MAJOR} docker-dind-${DOCKER_MAJOR} mount sudo"
+
+if [ "${INSTALL_DOCKER_BUILDX}" = "true" ]; then
+    PACKAGES="${PACKAGES} docker-cli-buildx"
+fi
+
+if [ "${DOCKER_DASH_COMPOSE_VERSION}" = "v2" ]; then
+    PACKAGES="${PACKAGES} docker-compose"
+fi
+
+echo "Installing packages: ${PACKAGES}"
+apk add --no-cache ${PACKAGES}
+
+ensure_user
+
+if ! grep -qE '^docker:' /etc/group; then
+    echo "(*) Creating missing docker group..."
+    addgroup -S docker
+fi
+
+if [ "${FEATURE_USER}" != "root" ]; then
+    if ! id -nG "${FEATURE_USER}" | tr ' ' '\n' | grep -qx docker; then
+        addgroup "${FEATURE_USER}" docker
+    fi
+    mkdir -p /etc/sudoers.d
+    if [ ! -f "/etc/sudoers.d/${FEATURE_USER}" ]; then
+        echo "${FEATURE_USER} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${FEATURE_USER}"
+        chmod 0440 "/etc/sudoers.d/${FEATURE_USER}"
+    fi
+fi
+
+DOCKER_DEFAULT_IP6_TABLES=""
+if [ "${DISABLE_IP6_TABLES}" = "true" ]; then
+    DOCKER_DEFAULT_IP6_TABLES="--ip6tables=false"
+fi
+
+mkdir -p /usr/local/share
+mkdir -p /usr/local/share/docker-in-docker
+
+if [ ! -e /var/run ]; then
+    ln -s /run /var/run
+fi
+
+install -m755 ./dockerd-entrypoint.sh /usr/local/share/docker-in-docker/dockerd-entrypoint.sh
+
+cat > "${INIT_SCRIPT}" <<EOF
+#!/bin/sh
+set -e
+
+AZURE_DNS_AUTO_DETECTION='${AZURE_DNS_AUTO_DETECTION}'
+DOCKER_DEFAULT_ADDRESS_POOL='${DOCKER_DEFAULT_ADDRESS_POOL}'
+DOCKER_DEFAULT_IP6_TABLES='${DOCKER_DEFAULT_IP6_TABLES}'
+EOF
+
+cat >> "${INIT_SCRIPT}" <<'EOF'
+sudo_if() {
+    if [ "$(id -u)" -ne 0 ]; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
+start_dockerd() {
+    if grep -qi 'internal.cloudapp.net' /etc/resolv.conf 2>/dev/null && [ "${AZURE_DNS_AUTO_DETECTION}" = "true" ]; then
+        echo "Setting dockerd Azure DNS."
+        CUSTOMDNS="--dns 168.63.129.16"
+    else
+        echo "Not setting dockerd DNS manually."
+        CUSTOMDNS=""
+    fi
+
+    if [ -n "${DOCKER_DEFAULT_ADDRESS_POOL}" ]; then
+        DEFAULT_ADDRESS_POOL="--default-address-pool ${DOCKER_DEFAULT_ADDRESS_POOL}"
+    else
+        DEFAULT_ADDRESS_POOL=""
+    fi
+
+    START_COMMAND="find /run /var/run -iname 'docker*.pid' -delete || :; find /run /var/run -iname 'container*.pid' -delete || :; /usr/bin/dind /usr/local/share/docker-in-docker/dockerd-entrypoint.sh dockerd ${CUSTOMDNS} ${DEFAULT_ADDRESS_POOL} ${DOCKER_DEFAULT_IP6_TABLES} > /tmp/dockerd.log 2>&1 &"
+
+    if [ "$(id -u)" -ne 0 ]; then
+        sudo /bin/sh -c "${START_COMMAND}"
+    else
+        /bin/sh -c "${START_COMMAND}"
+    fi
+}
+
+retry_docker_start_count=0
+docker_ok="false"
+
+until [ "${docker_ok}" = "true" ] || [ "${retry_docker_start_count}" -eq "5" ];
+do
+    start_dockerd
+
+    retry_count=0
+    until [ "${docker_ok}" = "true" ] || [ "${retry_count}" -eq "10" ];
+    do
+        sleep 1
+        set +e
+        docker info >/dev/null 2>&1 && docker_ok="true"
+        set -e
+        retry_count=`expr ${retry_count} + 1`
+    done
+
+    if [ "${docker_ok}" != "true" ] && [ "${retry_docker_start_count}" != "4" ]; then
+        echo "(*) Failed to start docker, retrying..."
+        set +e
+        sudo_if pkill dockerd
+        sudo_if pkill containerd
+        set -e
+    fi
+
+    retry_docker_start_count=`expr ${retry_docker_start_count} + 1`
+done
+
+if [ "${docker_ok}" != "true" ]; then
+    echo "Docker failed to start."
+    if [ -f /tmp/dockerd.log ]; then
+        cat /tmp/dockerd.log
+    fi
+    exit 1
+fi
+
+exec "$@"
+EOF
+
+chmod +x "${INIT_SCRIPT}"
+chown "${FEATURE_USER}":root "${INIT_SCRIPT}"
+
+echo "Done!"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -197,13 +197,15 @@ sudo_if() {
     fi
 }
 
+DOCKERD_PID=""
+
 start_dockerd() {
     set +e
     sudo_if find /run /var/run -iname 'docker*.pid' -delete
     sudo_if find /run /var/run -iname 'container*.pid' -delete
     set -e
 
-    set -- "${DIND_BIN}" /usr/local/share/docker-in-docker/dockerd-entrypoint.sh dockerd
+    set -- "${DIND_BIN}" /usr/local/share/docker-in-docker/dockerd-entrypoint.sh
 
     if grep -qi 'internal.cloudapp.net' /etc/resolv.conf 2>/dev/null && [ "${AZURE_DNS_AUTO_DETECTION}" = "true" ]; then
         echo "Setting dockerd Azure DNS."
@@ -222,10 +224,24 @@ start_dockerd() {
 
     if [ "$(id -u)" -ne 0 ]; then
         sudo "$@" > /tmp/dockerd.log 2>&1 &
+    else
+        "$@" > /tmp/dockerd.log 2>&1 &
+    fi
+
+    DOCKERD_PID=$!
+}
+
+stop_dockerd() {
+    if [ -z "${DOCKERD_PID}" ]; then
         return
     fi
 
-    "$@" > /tmp/dockerd.log 2>&1 &
+    set +e
+    sudo_if kill "${DOCKERD_PID}" >/dev/null 2>&1
+    wait "${DOCKERD_PID}" >/dev/null 2>&1
+    set -e
+
+    DOCKERD_PID=""
 }
 
 retry_docker_start_count=0
@@ -247,10 +263,7 @@ do
 
     if [ "${docker_ok}" != "true" ] && [ "${retry_docker_start_count}" != "4" ]; then
         echo "(*) Failed to start docker, retrying..."
-        set +e
-        sudo_if pkill dockerd
-        sudo_if pkill containerd
-        set -e
+        stop_dockerd
     fi
 
     retry_docker_start_count=`expr ${retry_docker_start_count} + 1`

--- a/test/docker-in-docker/Dockerfile
+++ b/test/docker-in-docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+LABEL org.opencontainers.image.title="docker-in-docker-test"

--- a/test/docker-in-docker/azure_dns_autodetection_false.sh
+++ b/test/docker-in-docker/azure_dns_autodetection_false.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "azure dns disabled in init" bash -c "grep -F \"AZURE_DNS_AUTO_DETECTION='false'\" /usr/local/share/docker-in-docker-init.sh"
+
+reportResults

--- a/test/docker-in-docker/default.sh
+++ b/test/docker-in-docker/default.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "docker version" docker --version
+check "docker init script" ls -l /usr/local/share/docker-in-docker-init.sh
+check "docker ps" docker ps
+check "docker build" docker build ./
+check "docker buildx" docker buildx version
+check "docker-compose" docker-compose --version
+
+reportResults

--- a/test/docker-in-docker/disable_ip6tables.sh
+++ b/test/docker-in-docker/disable_ip6tables.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "ip6tables flag" bash -c "ps -axww | grep -v grep | grep -F -- '--ip6tables=false'"
+check "docker ps" docker ps
+
+reportResults

--- a/test/docker-in-docker/docker_default_address_pool.sh
+++ b/test/docker-in-docker/docker_default_address_pool.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "default address pool flag" bash -c "ps -axww | grep -v grep | grep -F -- '--default-address-pool base=192.168.0.0/16,size=24'"
+
+reportResults

--- a/test/docker-in-docker/docker_default_address_pool.sh
+++ b/test/docker-in-docker/docker_default_address_pool.sh
@@ -4,6 +4,6 @@ set -e
 
 source dev-container-features-test-lib
 
-check "default address pool flag" bash -c "ps -axww | grep -v grep | grep -F -- '--default-address-pool base=192.168.0.0/16,size=24'"
+check "default address pool flag" bash -c "ps -axww | grep -v grep | grep -F -- '--default-address-pool=base=192.168.0.0/16,size=24'"
 
 reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -46,5 +46,15 @@
             }
         },
         "containerUser": "vscode"
+    },
+    "azure_dns_autodetection_false": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "docker-in-docker": {
+                "azureDnsAutoDetection": false
+            }
+        },
+        "containerUser": "vscode"
     }
 }

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -1,0 +1,50 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "docker-in-docker": {}
+        },
+        "containerUser": "vscode"
+    },
+    "without_compose": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "docker-in-docker": {
+                "dockerDashComposeVersion": "none"
+            }
+        },
+        "containerUser": "vscode"
+    },
+    "without_buildx": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "docker-in-docker": {
+                "installDockerBuildx": false
+            }
+        },
+        "containerUser": "vscode"
+    },
+    "docker_default_address_pool": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "docker-in-docker": {
+                "dockerDefaultAddressPool": "base=192.168.0.0/16,size=24"
+            }
+        },
+        "containerUser": "vscode"
+    },
+    "disable_ip6tables": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "docker-in-docker": {
+                "disableIp6tables": true
+            }
+        },
+        "containerUser": "vscode"
+    }
+}

--- a/test/docker-in-docker/without_buildx.sh
+++ b/test/docker-in-docker/without_buildx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "docker version" docker --version
+check "docker ps" docker ps
+check "buildx not installed" bash -c "! docker buildx version"
+check "docker-compose" docker-compose --version
+
+reportResults

--- a/test/docker-in-docker/without_compose.sh
+++ b/test/docker-in-docker/without_compose.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "docker version" docker --version
+check "docker ps" docker ps
+check "docker buildx" docker buildx version
+check "docker-compose not installed" bash -c "! command -v docker-compose"
+check "docker compose unavailable" bash -c "! docker compose version"
+
+reportResults


### PR DESCRIPTION
## Summary
- add a new `docker-in-docker` feature for Wolfi that installs Docker engine, buildx, and optional compose using Wolfi packages
- start the inner daemon through a Wolfi-friendly init wrapper and vendored `dockerd-entrypoint.sh`, including address pool and ip6tables options
- add scenario coverage for default, no compose, no buildx, custom address pool, and disabled ip6tables, and include the feature in CI

## Testing
- `devcontainer features test -f docker-in-docker --skip-autogenerated --skip-duplicated .`

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a docker-in-docker feature to run an inner Docker daemon in development containers with configurable Buildx, Compose, Azure DNS, default address pool and IPv6 handling; includes installer and runtime init tooling.

* **Documentation**
  * Added feature documentation and updated README with usage examples and option descriptions.

* **Tests**
  * Added scenario-based integration tests validating multiple docker-in-docker configurations and behaviors.

* **Chores**
  * CI test matrix updated to include docker-in-docker scenario runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->