### PR TITLE
Add optional Docker config import to docker-in-docker

### DIFF
--- a/src/docker-in-docker/NOTES.md
+++ b/src/docker-in-docker/NOTES.md
@@ -1,0 +1,11 @@
+## Usage notes
+
+- `copyDockerConfig` enables a startup hook that copies `/tmp/docker-in-docker-host-tmp/config.json` into the resolved devcontainer user's `~/.docker/config.json`.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/docker-in-docker` to `/tmp/docker-in-docker-host-tmp`.
+- The mount is always configured. Use the host helper script or an `initializeCommand` to ensure `${localEnv:TEMP:/tmp}/docker-in-docker` exists before container startup.
+- Use the host scripts in `src/docker-in-docker/host/docker-config-copy` (POSIX) and `src/docker-in-docker/host/docker-config-copy.cmd` (Windows). Call the shared base name `docker-config-copy` from `initializeCommand` so each OS resolves the right script and copy `config.json` from either `${DOCKER_CONFIG}/config.json` when `DOCKER_CONFIG` is set or the default host location (`~/.docker/config.json` on macOS/Linux, `%USERPROFILE%\.docker\config.json` on Windows).
+- Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/docker-config-copy"
+```

--- a/src/docker-in-docker/README.md
+++ b/src/docker-in-docker/README.md
@@ -21,6 +21,7 @@ Run a Docker daemon inside Wolfi-based development containers using Wolfi packag
 | dockerDefaultAddressPool | Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24 | string | - |
 | disableIptables | Disable iptables for the inner Docker daemon. Useful when nested Docker providers manage networking outside the container. | boolean | false |
 | disableIp6tables | Disable ip6tables for the inner Docker daemon. | boolean | false |
+| copyDockerConfig | Whether to copy Docker config.json from the host into the container. | boolean | false |
 
 ## Customizations
 
@@ -28,6 +29,17 @@ Run a Docker daemon inside Wolfi-based development containers using Wolfi packag
 
 - `ms-azuretools.vscode-docker`
 
+## Usage notes
+
+- `copyDockerConfig` enables a startup hook that copies `/tmp/docker-in-docker-host-tmp/config.json` into the resolved devcontainer user's `~/.docker/config.json`.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/docker-in-docker` to `/tmp/docker-in-docker-host-tmp`.
+- The mount is always configured. Use the host helper script or an `initializeCommand` to ensure `${localEnv:TEMP:/tmp}/docker-in-docker` exists before container startup.
+- Use the host scripts in `src/docker-in-docker/host/docker-config-copy` (POSIX) and `src/docker-in-docker/host/docker-config-copy.cmd` (Windows). Call the shared base name `docker-config-copy` from `initializeCommand` so each OS resolves the right script and copy `config.json` from either `${DOCKER_CONFIG}/config.json` when `DOCKER_CONFIG` is set or the default host location (`~/.docker/config.json` on macOS/Linux, `%USERPROFILE%\.docker\config.json` on Windows).
+- Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/docker-config-copy"
+```
 
 
 ---

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "docker-in-docker",
   "id": "docker-in-docker",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Run a Docker daemon inside Wolfi-based development containers using Wolfi packages.",
   "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/docker-in-docker",
   "options": {
@@ -35,9 +35,15 @@
       "type": "boolean",
       "default": false,
       "description": "Disable ip6tables for the inner Docker daemon."
+    },
+    "copyDockerConfig": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to copy Docker config.json from the host into the container."
     }
   },
   "entrypoint": "/usr/local/share/docker-init.sh",
+  "postStartCommand": "/usr/local/share/docker-config-copy.sh",
   "privileged": true,
   "containerEnv": {
     "DOCKER_BUILDKIT": "1"
@@ -47,6 +53,11 @@
       "source": "dind-var-lib-docker-${devcontainerId}",
       "target": "/var/lib/docker",
       "type": "volume"
+    },
+    {
+      "source": "${localEnv:TEMP:/tmp}/docker-in-docker",
+      "target": "/tmp/docker-in-docker-host-tmp",
+      "type": "bind"
     }
   ],
   "customizations": {

--- a/src/docker-in-docker/host/docker-config-copy
+++ b/src/docker-in-docker/host/docker-config-copy
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+TEMP_DIR=${TEMP:-"/tmp"}
+TARGET_DIR="${TEMP_DIR}/docker-in-docker"
+TARGET_CONFIG="${TARGET_DIR}/config.json"
+
+if [ -n "${DOCKER_CONFIG:-}" ]; then
+    SOURCE_CONFIG="${DOCKER_CONFIG}/config.json"
+else
+    SOURCE_CONFIG="${HOME}/.docker/config.json"
+fi
+
+mkdir -p "${TARGET_DIR}"
+
+if [ -f "${SOURCE_CONFIG}" ]; then
+    cp "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
+    chmod 600 "${TARGET_CONFIG}"
+fi

--- a/src/docker-in-docker/host/docker-config-copy.cmd
+++ b/src/docker-in-docker/host/docker-config-copy.cmd
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+
+set "TEMP_DIR=%TEMP%"
+if "%TEMP_DIR%"=="" set "TEMP_DIR=%TMP%"
+if "%TEMP_DIR%"=="" set "TEMP_DIR=%SystemRoot%\Temp"
+
+set "TARGET_DIR=%TEMP_DIR%\docker-in-docker"
+set "TARGET_CONFIG=%TARGET_DIR%\config.json"
+
+if not "%DOCKER_CONFIG%"=="" (
+    set "SOURCE_CONFIG=%DOCKER_CONFIG%\config.json"
+) else (
+    set "SOURCE_CONFIG=%USERPROFILE%\.docker\config.json"
+)
+
+if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+
+if exist "%SOURCE_CONFIG%" (
+    copy /Y "%SOURCE_CONFIG%" "%TARGET_CONFIG%" >nul
+)
+
+endlocal

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -209,7 +209,7 @@ if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_CONFIG}" ]; then
     cp "\${SOURCE_CONFIG}" "\${TARGET_CONFIG}"
 
     if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
-        TARGET_GROUP=$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        TARGET_GROUP=\$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
         if [ -n "\${TARGET_GROUP}" ]; then
             chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
         else

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -7,6 +7,7 @@ AZURE_DNS_AUTO_DETECTION=${AZUREDNSAUTODETECTION:-"true"}
 DOCKER_DEFAULT_ADDRESS_POOL=${DOCKERDEFAULTADDRESSPOOL:-""}
 DISABLE_IP_TABLES=${DISABLEIPTABLES:-"false"}
 DISABLE_IP6_TABLES=${DISABLEIP6TABLES:-"false"}
+COPY_DOCKER_CONFIG=${COPYDOCKERCONFIG:-"false"}
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 DOCKER_MAJOR="29"
 INIT_SCRIPT="/usr/local/share/docker-init.sh"
@@ -107,10 +108,28 @@ ensure_user() {
     chown -R "${FEATURE_USER}:$(id -gn "${FEATURE_USER}")" "/home/${FEATURE_USER}"
 }
 
+resolve_user_home() {
+    USER_NAME="$1"
+
+    if [ "${USER_NAME}" = "root" ]; then
+        echo "/root"
+        return
+    fi
+
+    HOME_DIR="$(awk -F: -v user="${USER_NAME}" '$1==user{print $6}' /etc/passwd)"
+    if [ -n "${HOME_DIR}" ]; then
+        echo "${HOME_DIR}"
+        return
+    fi
+
+    echo "/home/${USER_NAME}"
+}
+
 validate_bool "${INSTALL_DOCKER_BUILDX}" "installDockerBuildx"
 validate_bool "${AZURE_DNS_AUTO_DETECTION}" "azureDnsAutoDetection"
 validate_bool "${DISABLE_IP_TABLES}" "disableIptables"
 validate_bool "${DISABLE_IP6_TABLES}" "disableIp6tables"
+validate_bool "${COPY_DOCKER_CONFIG}" "copyDockerConfig"
 validate_address_pool "${DOCKER_DEFAULT_ADDRESS_POOL}"
 
 case "${DOCKER_DASH_COMPOSE_VERSION}" in
@@ -143,6 +162,7 @@ echo "Installing packages: ${PACKAGES}"
 apk add --no-cache ${PACKAGES}
 
 ensure_user
+FEATURE_HOME="$(resolve_user_home "${FEATURE_USER}")"
 
 if ! grep -qE '^docker:' /etc/group; then
     echo "(*) Creating missing docker group..."
@@ -171,6 +191,45 @@ if [ "${DISABLE_IP6_TABLES}" = "true" ]; then
 fi
 
 mkdir -p /usr/local/share
+
+cat > /usr/local/share/docker-config-copy.sh <<EOF
+#!/bin/sh
+set -e
+
+SOURCE_CONFIG="/tmp/docker-in-docker-host-tmp/config.json"
+FLAG_FILE="/usr/local/share/docker-copyconfig.flag"
+TARGET_USER="${FEATURE_USER}"
+TARGET_HOME="${FEATURE_HOME}"
+
+TARGET_DIR="\${TARGET_HOME}/.docker"
+TARGET_CONFIG="\${TARGET_DIR}/config.json"
+
+if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_CONFIG}" ]; then
+    mkdir -p "\${TARGET_DIR}"
+    cp "\${SOURCE_CONFIG}" "\${TARGET_CONFIG}"
+
+    if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "\${TARGET_GROUP}" ]; then
+            chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
+        else
+            chown "\${TARGET_USER}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
+        fi
+    fi
+
+    chmod 700 "\${TARGET_DIR}"
+    chmod 600 "\${TARGET_CONFIG}"
+fi
+EOF
+
+chmod +x /usr/local/share/docker-config-copy.sh
+
+if [ "${COPY_DOCKER_CONFIG}" = "true" ]; then
+    echo "Enabling Docker config copy"
+    : > /usr/local/share/docker-copyconfig.flag
+else
+    rm -f /usr/local/share/docker-copyconfig.flag
+fi
 
 if [ ! -e /var/run ]; then
     ln -s /run /var/run

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -1,6 +1,9 @@
 {
   "default": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {}
@@ -9,6 +12,9 @@
   },
   "without_compose": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {
@@ -19,6 +25,9 @@
   },
   "without_buildx": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {
@@ -29,6 +38,9 @@
   },
   "docker_default_address_pool": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {
@@ -39,6 +51,9 @@
   },
   "disable_iptables": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {
@@ -49,6 +64,9 @@
   },
   "disable_ip6tables": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {
@@ -59,10 +77,26 @@
   },
   "azure_dns_autodetection_false": {
     "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "mkdir-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker || true"
+    },
     "features": {
       "bash": {},
       "docker-in-docker": {
         "azureDnsAutoDetection": false
+      }
+    },
+    "containerUser": "vscode"
+  },
+  "with_docker_config": {
+    "image": "chainguard/wolfi-base:latest",
+    "initializeCommand": {
+      "prepare-posix": "mkdir -p ${TEMP:-/tmp}/docker-in-docker && printf '{\"auths\":{\"example.invalid\":{}}}\n' > ${TEMP:-/tmp}/docker-in-docker/config.json || true"
+    },
+    "features": {
+      "bash": {},
+      "docker-in-docker": {
+        "copyDockerConfig": true
       }
     },
     "containerUser": "vscode"

--- a/test/docker-in-docker/with_docker_config.sh
+++ b/test/docker-in-docker/with_docker_config.sh
@@ -25,6 +25,7 @@ SOURCE_CONFIG="/tmp/docker-in-docker-host-tmp/config.json"
 
 check "docker config copy hook installed" test -f /usr/local/share/docker-config-copy.sh
 check "docker config copy flag installed" test -f /usr/local/share/docker-copyconfig.flag
+check "docker config copy resolves group at runtime" grep -q 'TARGET_GROUP=$(id -gn "${TARGET_USER}"' /usr/local/share/docker-config-copy.sh
 
 if [ -f "${SOURCE_CONFIG}" ]; then
     wait_for_file "${TARGET_CONFIG}"

--- a/test/docker-in-docker/with_docker_config.sh
+++ b/test/docker-in-docker/with_docker_config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+wait_for_file() {
+    TARGET_PATH="$1"
+    ATTEMPT=0
+
+    while [ ! -f "${TARGET_PATH}" ] && [ "${ATTEMPT}" -lt "10" ]; do
+        sleep 1
+        ATTEMPT=$((ATTEMPT + 1))
+    done
+}
+
+TARGET_HOME=$(awk -F= '/^TARGET_HOME=/{gsub(/"/, "", $2); print $2; exit}' /usr/local/share/docker-config-copy.sh)
+
+if [ -z "${TARGET_HOME}" ]; then
+    TARGET_HOME="${HOME:-/root}"
+fi
+
+TARGET_CONFIG="${TARGET_HOME}/.docker/config.json"
+SOURCE_CONFIG="/tmp/docker-in-docker-host-tmp/config.json"
+
+check "docker config copy hook installed" test -f /usr/local/share/docker-config-copy.sh
+check "docker config copy flag installed" test -f /usr/local/share/docker-copyconfig.flag
+
+if [ -f "${SOURCE_CONFIG}" ]; then
+    wait_for_file "${TARGET_CONFIG}"
+    check "docker config copied" test -f "${TARGET_CONFIG}"
+    check "docker config content matches" cmp -s "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
+else
+    check "docker config missing on host" test ! -f "${TARGET_CONFIG}"
+fi
+
+reportResults


### PR DESCRIPTION
## Summary
- add an opt-in `copyDockerConfig` feature option, temp bind mount, and post-start copy hook so the resolved devcontainer user can receive host Docker client config at `~/.docker/config.json`
- add cross-platform host helper scripts and usage notes for the existing `/tmp` staging pattern used by other features
- add scenario coverage for the new copy flow and ensure the docker-in-docker scenarios prepare the mounted temp directory consistently

## Testing
- `devcontainer features package ./src -o ./output/features --force-clean-output-folder`
- `devcontainer features test --project-folder . --features docker-in-docker --skip-autogenerated --skip-duplicated --filter with_docker_config`
- `devcontainer features test --project-folder . --features docker-in-docker --skip-autogenerated --skip-duplicated -q`

Closes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced copyDockerConfig (disabled by default) to copy host Docker config into the container and an optional post-start helper to apply it.
  * Added a host-temp bind mount to support the config copy workflow.

* **Documentation**
  * Added usage notes and setup guidance for enabling and preparing the host-side helper scripts.

* **Tests**
  * Added tests covering Docker config propagation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/davzucky/devcontainers-features-wolfi/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->