### PR TITLE
Add opencode config copy support

### DIFF
--- a/src/opencode/NOTES.md
+++ b/src/opencode/NOTES.md
@@ -3,8 +3,9 @@
 - `version` supports `latest` (resolved from the GitHub releases latest tag) or an explicit version (with or without a leading `v`).
 - The installer ensures `ripgrep` (`rg`) is present because `opencode` requires it.
 - `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
+- `copyConfig` enables the same startup hook to copy `/tmp/opencode-host-tmp/opencode.json` into `$HOME/.config/opencode/opencode.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
-- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script and copy `auth.json` from either:
+- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script. The script copies `opencode.json` from `~/.config/opencode/opencode.json` and copies `auth.json` from either:
   - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
   - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).
 - Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):

--- a/src/opencode/README.md
+++ b/src/opencode/README.md
@@ -17,14 +17,16 @@ Installs opencode CLI on Wolfi base images.
 |-----|-----|-----|-----|
 | version | Select the opencode CLI version to install. | string | latest |
 | copyAuth | Whether to copy opencode auth.json from the host into the container. | boolean | false |
+| copyConfig | Whether to copy opencode opencode.json from the host into the container. | boolean | false |
 
 ## Usage notes
 
 - `version` supports `latest` (resolved from the GitHub releases latest tag) or an explicit version (with or without a leading `v`).
 - The installer ensures `ripgrep` (`rg`) is present because `opencode` requires it.
 - `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
+- `copyConfig` enables the same startup hook to copy `/tmp/opencode-host-tmp/opencode.json` into `$HOME/.config/opencode/opencode.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
-- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script and copy `auth.json` from either:
+- Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script. The script copies `opencode.json` from `~/.config/opencode/opencode.json` and copies `auth.json` from either:
   - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
   - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).
 - Example `initializeCommand` (copy both scripts into your repo, for example `.devcontainer/`):

--- a/src/opencode/devcontainer-feature.json
+++ b/src/opencode/devcontainer-feature.json
@@ -14,6 +14,11 @@
             "type": "boolean",
             "default": false,
             "description": "Whether to copy opencode auth.json from the host into the container."
+        },
+        "copyConfig": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to copy opencode opencode.json from the host into the container."
         }
     },
     "mounts": [

--- a/src/opencode/host/opencode-auth-copy
+++ b/src/opencode/host/opencode-auth-copy
@@ -4,6 +4,7 @@ set -e
 TEMP_DIR=${TEMP:-"/tmp"}
 TARGET_DIR="${TEMP_DIR}/opencode"
 TARGET_AUTH="${TARGET_DIR}/auth.json"
+TARGET_CONFIG="${TARGET_DIR}/opencode.json"
 
 if [ -n "${OPENCODE_CONFIG_DIR:-}" ]; then
     SOURCE_AUTH="${OPENCODE_CONFIG_DIR}/auth.json"
@@ -11,9 +12,16 @@ else
     SOURCE_AUTH="${HOME}/.local/share/opencode/auth.json"
 fi
 
+SOURCE_CONFIG="${HOME}/.config/opencode/opencode.json"
+
 mkdir -p "${TARGET_DIR}"
 
 if [ -f "${SOURCE_AUTH}" ]; then
     cp "${SOURCE_AUTH}" "${TARGET_AUTH}"
     chmod 600 "${TARGET_AUTH}"
+fi
+
+if [ -f "${SOURCE_CONFIG}" ]; then
+    cp "${SOURCE_CONFIG}" "${TARGET_CONFIG}"
+    chmod 600 "${TARGET_CONFIG}"
 fi

--- a/src/opencode/host/opencode-auth-copy.cmd
+++ b/src/opencode/host/opencode-auth-copy.cmd
@@ -6,6 +6,7 @@ if "%TEMP_DIR%"=="" set "TEMP_DIR=/tmp"
 
 set "TARGET_DIR=%TEMP_DIR%\opencode"
 set "TARGET_AUTH=%TARGET_DIR%\auth.json"
+set "TARGET_CONFIG=%TARGET_DIR%\opencode.json"
 
 if not "%OPENCODE_CONFIG_DIR%"=="" (
     set "SOURCE_AUTH=%OPENCODE_CONFIG_DIR%\auth.json"
@@ -13,10 +14,16 @@ if not "%OPENCODE_CONFIG_DIR%"=="" (
     set "SOURCE_AUTH=%USERPROFILE%\.local\share\opencode\auth.json"
 )
 
+set "SOURCE_CONFIG=%USERPROFILE%\.config\opencode\opencode.json"
+
 if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
 
 if exist "%SOURCE_AUTH%" (
     copy /Y "%SOURCE_AUTH%" "%TARGET_AUTH%" >nul
+)
+
+if exist "%SOURCE_CONFIG%" (
+    copy /Y "%SOURCE_CONFIG%" "%TARGET_CONFIG%" >nul
 )
 
 endlocal

--- a/src/opencode/install.sh
+++ b/src/opencode/install.sh
@@ -3,6 +3,7 @@ set -e
 
 VERSION=${VERSION:-"latest"}
 COPY_AUTH=${COPYAUTH:-"false"}
+COPY_CONFIG=${COPYCONFIG:-"false"}
 
 ARCH=$(uname -m)
 ARCHIVE_NAME=""
@@ -84,7 +85,7 @@ if ! command -v opencode >/dev/null 2>&1; then
     exit 1
 fi
 
-echo "Installing opencode auth copy hook"
+echo "Installing opencode config copy hook"
 mkdir -p /usr/local/share
 
 RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
@@ -121,11 +122,14 @@ cat <<EOF > /usr/local/share/opencode-auth-copy.sh
 set -e
 
 SOURCE_AUTH="/tmp/opencode-host-tmp/auth.json"
+SOURCE_CONFIG="/tmp/opencode-host-tmp/opencode.json"
 FLAG_FILE="/usr/local/share/opencode-copyauth.flag"
+CONFIG_FLAG_FILE="/usr/local/share/opencode-copyconfig.flag"
 TARGET_USER="${RESOLVED_TARGET_USER}"
 TARGET_HOME="${RESOLVED_TARGET_HOME}"
 
 TARGET_AUTH="\${TARGET_HOME}/.local/share/opencode/auth.json"
+TARGET_CONFIG="\${TARGET_HOME}/.config/opencode/opencode.json"
 
 if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_AUTH}" ]; then
     TARGET_DIR=\$(dirname "\${TARGET_AUTH}")
@@ -145,6 +149,24 @@ if [ -f "\${FLAG_FILE}" ] && [ -f "\${SOURCE_AUTH}" ]; then
     chmod 600 "\${TARGET_AUTH}"
 fi
 
+if [ -f "\${CONFIG_FLAG_FILE}" ] && [ -f "\${SOURCE_CONFIG}" ]; then
+    TARGET_DIR=\$(dirname "\${TARGET_CONFIG}")
+    mkdir -p "\${TARGET_DIR}"
+    cp "\${SOURCE_CONFIG}" "\${TARGET_CONFIG}"
+
+    if [ -n "\${TARGET_USER}" ] && id -u "\${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=\$(id -gn "\${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "\${TARGET_GROUP}" ]; then
+            chown "\${TARGET_USER}:\${TARGET_GROUP}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
+        else
+            chown "\${TARGET_USER}" "\${TARGET_DIR}" "\${TARGET_CONFIG}"
+        fi
+    fi
+
+    chmod 700 "\${TARGET_DIR}"
+    chmod 600 "\${TARGET_CONFIG}"
+fi
+
 EOF
 
 chmod +x /usr/local/share/opencode-auth-copy.sh
@@ -154,6 +176,13 @@ if [ "${COPY_AUTH}" = "true" ]; then
     : > /usr/local/share/opencode-copyauth.flag
 else
     rm -f /usr/local/share/opencode-copyauth.flag
+fi
+
+if [ "${COPY_CONFIG}" = "true" ]; then
+    echo "Enabling opencode config copy"
+    : > /usr/local/share/opencode-copyconfig.flag
+else
+    rm -f /usr/local/share/opencode-copyconfig.flag
 fi
 
 echo "opencode installed successfully"

--- a/test/opencode/scenarios.json
+++ b/test/opencode/scenarios.json
@@ -20,5 +20,17 @@
                 "copyAuth": true
             }
         }
+    },
+    "with_config": {
+        "image": "chainguard/wolfi-base:latest",
+        "initializeCommand": {
+            "prepare-posix": "mkdir -p ${TEMP:-/tmp}/opencode && printf '{\"theme\":\"dark\"}' > ${TEMP:-/tmp}/opencode/opencode.json || true"
+        },
+        "features": {
+            "bash": {},
+            "opencode": {
+                "copyConfig": true
+            }
+        }
     }
 }

--- a/test/opencode/with_config.sh
+++ b/test/opencode/with_config.sh
@@ -4,11 +4,6 @@ set -e
 
 source dev-container-features-test-lib
 
-check "opencode installed" opencode --version
-check "ripgrep installed" rg --version
-check "auth copy flag missing" test ! -f /usr/local/share/opencode-copyauth.flag
-check "config copy flag missing" test ! -f /usr/local/share/opencode-copyconfig.flag
-
 TARGET_USER="${_REMOTE_USER:-}"
 TARGET_HOME=""
 
@@ -37,9 +32,16 @@ if [ -z "${TARGET_HOME}" ]; then
     TARGET_HOME="/root"
 fi
 
-TARGET_AUTH="${TARGET_HOME}/.local/share/opencode/auth.json"
 TARGET_CONFIG="${TARGET_HOME}/.config/opencode/opencode.json"
-check "auth file missing" test ! -f "${TARGET_AUTH}"
-check "config file missing" test ! -f "${TARGET_CONFIG}"
+SOURCE_CONFIG="/tmp/opencode-host-tmp/opencode.json"
+
+check "config copy hook installed" test -f /usr/local/share/opencode-auth-copy.sh
+check "config copy flag installed" test -f /usr/local/share/opencode-copyconfig.flag
+
+if [ -f "${SOURCE_CONFIG}" ]; then
+    check "config copied" test -f "${TARGET_CONFIG}"
+else
+    check "config missing on host" test ! -f "${TARGET_CONFIG}"
+fi
 
 reportResults


### PR DESCRIPTION
## Summary
- Add `copyConfig` option to the opencode feature
- Copy staged `opencode.json` into `$HOME/.config/opencode/opencode.json` at startup when enabled
- Extend host helper scripts and add a focused scenario test

Closes #95

## Testing
- `sh -n src/opencode/install.sh src/opencode/host/opencode-auth-copy`
- `jq empty src/opencode/devcontainer-feature.json test/opencode/scenarios.json`
- `devcontainer features test -f opencode --skip-autogenerated --skip-duplicated --filter with_config .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `copyConfig` option that copies host configuration into the container during startup.

* **Documentation**
  * Updated guides to document the new configuration option and startup behavior.

* **Tests**
  * Added test scenarios and assertions to validate configuration file handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/davzucky/devcontainers-features-wolfi/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->