### PR TITLE
Add reusable agent-skills feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         features:
+          - agent-skills
           - bash
           - chromium
           - common-utils

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: Remote user, target user, container user
 The user-level Pi configuration directory at `~/.pi/agent` containing Pi settings, credentials, customizations, and installed Pi packages. In this repository's Pi feature discussions, `.pi/agent` means `~/.pi/agent` unless explicitly described as project-local.
 _Avoid_: Pi config folder, Pi home
 
+**Shared agent skills directory**:
+The user-level shared agent skills directory at `~/.agents/skills`. It is preserved as its own directory in containers, separate from the Pi agent directory, because it is a cross-harness standard reused by tools such as Pi and opencode. Claude Code does not use this standard.
+_Avoid_: Pi skills folder, shared Pi skills
+
 ## Example dialogue
 
 Developer: Should the Pi feature copy the whole Pi agent directory into the container running user's home?

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Most of the features available for devcontainers usually expect you to run a deb
 
 The following features are available:
 
+- [agent-skills](./src/agent-skills/README.md) - Copies shared agent skills into the container running user's home
 - [bash](./src/bash/README.md) - Installs bash and common shell utilities on Wolfi base images
 - [chromium](./src/chromium/README.md) - Installs Chromium browser on Wolfi base images
 - [common-utils](./src/common-utils/README.md) - Installs common command line utilities, configures users, and optionally sets up Zsh on Wolfi base images (lean Wolfi-native variant)

--- a/src/agent-skills/NOTES.md
+++ b/src/agent-skills/NOTES.md
@@ -1,0 +1,15 @@
+## Usage notes
+
+- This feature copies the shared agent skills directory standard, `~/.agents/skills`, into the container running user's home.
+- Including the feature enables copying by default; there are no options.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/agent-skills` to `/tmp/agent-skills-host-tmp`.
+- Use the host scripts in `src/agent-skills/host/agent-skills-copy` (POSIX) and `src/agent-skills/host/agent-skills-copy.cmd` (Windows). Call the shared base name `agent-skills-copy` from `initializeCommand` so each OS resolves the right script.
+- The host helper stages host `~/.agents/skills` into `${TEMP:-/tmp}/agent-skills/skills`. It creates an empty staging directory and exits successfully with a warning when shared agent skills are not configured on the host.
+- The container startup hook replaces the container running user's `~/.agents/skills` with the staged skills directory on each start.
+- Source permissions are preserved, including executable bits, and ownership is assigned to the container running user.
+
+Example `initializeCommand` (copy both host scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/agent-skills-copy"
+```

--- a/src/agent-skills/README.md
+++ b/src/agent-skills/README.md
@@ -1,0 +1,37 @@
+
+# agent-skills (agent-skills)
+
+Copies shared agent skills into the container running user's home.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/agent-skills:1": {}
+}
+```
+
+## Options
+
+This feature has no options.
+
+## Usage notes
+
+- This feature copies the shared agent skills directory standard, `~/.agents/skills`, into the container running user's home.
+- Including the feature enables copying by default; there are no options.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/agent-skills` to `/tmp/agent-skills-host-tmp`.
+- Use the host scripts in `src/agent-skills/host/agent-skills-copy` (POSIX) and `src/agent-skills/host/agent-skills-copy.cmd` (Windows). Call the shared base name `agent-skills-copy` from `initializeCommand` so each OS resolves the right script.
+- The host helper stages host `~/.agents/skills` into `${TEMP:-/tmp}/agent-skills/skills`. It creates an empty staging directory and exits successfully with a warning when shared agent skills are not configured on the host.
+- The container startup hook replaces the container running user's `~/.agents/skills` with the staged skills directory on each start.
+- Source permissions are preserved, including executable bits, and ownership is assigned to the container running user.
+
+Example `initializeCommand` (copy both host scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/agent-skills-copy"
+```
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/agent-skills/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/agent-skills/devcontainer-feature.json
+++ b/src/agent-skills/devcontainer-feature.json
@@ -1,0 +1,16 @@
+{
+    "name": "agent-skills",
+    "id": "agent-skills",
+    "version": "1.0.0",
+    "description": "Copies shared agent skills into the container running user's home.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/agent-skills",
+    "options": {},
+    "mounts": [
+        {
+            "source": "${localEnv:TEMP:/tmp}/agent-skills",
+            "target": "/tmp/agent-skills-host-tmp",
+            "type": "bind"
+        }
+    ],
+    "postStartCommand": "/usr/local/share/agent-skills-copy.sh"
+}

--- a/src/agent-skills/host/agent-skills-copy
+++ b/src/agent-skills/host/agent-skills-copy
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+TEMP_DIR=${TEMP:-"/tmp"}
+TARGET_ROOT="${TEMP_DIR}/agent-skills"
+TARGET_SKILLS="${TARGET_ROOT}/skills"
+SOURCE_SKILLS="${HOME}/.agents/skills"
+
+mkdir -p "${TARGET_ROOT}"
+rm -rf "${TARGET_SKILLS}"
+mkdir -p "${TARGET_SKILLS}"
+
+if [ ! -d "${SOURCE_SKILLS}" ]; then
+    echo "Shared agent skills directory not found; created empty staging directory: ${SOURCE_SKILLS}"
+    exit 0
+fi
+
+cp -Rp "${SOURCE_SKILLS}/." "${TARGET_SKILLS}/"

--- a/src/agent-skills/host/agent-skills-copy.cmd
+++ b/src/agent-skills/host/agent-skills-copy.cmd
@@ -1,0 +1,22 @@
+@echo off
+setlocal
+
+set "TEMP_DIR=%TEMP%"
+if "%TEMP_DIR%"=="" set "TEMP_DIR=/tmp"
+
+set "TARGET_ROOT=%TEMP_DIR%\agent-skills"
+set "TARGET_SKILLS=%TARGET_ROOT%\skills"
+set "SOURCE_SKILLS=%USERPROFILE%\.agents\skills"
+
+if not exist "%TARGET_ROOT%" mkdir "%TARGET_ROOT%"
+if exist "%TARGET_SKILLS%" rmdir /S /Q "%TARGET_SKILLS%"
+mkdir "%TARGET_SKILLS%"
+
+if not exist "%SOURCE_SKILLS%" (
+    echo Shared agent skills directory not found; created empty staging directory: %SOURCE_SKILLS%
+    exit /B 0
+)
+
+xcopy /E /I /Y "%SOURCE_SKILLS%" "%TARGET_SKILLS%" >nul
+
+endlocal

--- a/src/agent-skills/install.sh
+++ b/src/agent-skills/install.sh
@@ -67,7 +67,7 @@ if [ ! -d "${SOURCE_SKILLS}" ]; then
 fi
 
 rm -rf "${TARGET_SKILLS}"
-cp -R "${SOURCE_SKILLS}" "${TARGET_SKILLS}"
+cp -Rp "${SOURCE_SKILLS}" "${TARGET_SKILLS}"
 chmod 700 "${TARGET_AGENTS}" "${TARGET_SKILLS}"
 own_path "${TARGET_AGENTS}"
 HOOK_EOF

--- a/src/agent-skills/install.sh
+++ b/src/agent-skills/install.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -e
+
+mkdir -p /usr/local/share
+
+RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
+RESOLVED_TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
+    RESOLVED_TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${RESOLVED_TARGET_USER}" ] && id -u "${RESOLVED_TARGET_USER}" >/dev/null 2>&1; then
+    RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="${HOME}"
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] || [ -z "${RESOLVED_TARGET_HOME}" ] || [ "${RESOLVED_TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
+        RESOLVED_TARGET_USER="${FALLBACK_USER}"
+        RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+    fi
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] && [ -n "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_USER=$(awk -F: -v home="${RESOLVED_TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="/root"
+fi
+
+cat <<'HOOK_EOF' > /usr/local/share/agent-skills-copy.sh
+#!/bin/sh
+set -e
+
+SOURCE_SKILLS="/tmp/agent-skills-host-tmp/skills"
+TARGET_USER="__TARGET_USER__"
+TARGET_HOME="__TARGET_HOME__"
+TARGET_AGENTS="${TARGET_HOME}/.agents"
+TARGET_SKILLS="${TARGET_AGENTS}/skills"
+
+own_path() {
+    TARGET_PATH="$1"
+    if [ "$(id -u)" != "0" ]; then
+        return
+    fi
+
+    if [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=$(id -gn "${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "${TARGET_GROUP}" ]; then
+            chown -R "${TARGET_USER}:${TARGET_GROUP}" "${TARGET_PATH}"
+        else
+            chown -R "${TARGET_USER}" "${TARGET_PATH}"
+        fi
+    fi
+}
+
+mkdir -p "${TARGET_AGENTS}"
+
+if [ ! -d "${SOURCE_SKILLS}" ]; then
+    echo "Shared agent skills source directory missing, skipping copy: ${SOURCE_SKILLS}"
+    own_path "${TARGET_AGENTS}"
+    exit 0
+fi
+
+rm -rf "${TARGET_SKILLS}"
+cp -R "${SOURCE_SKILLS}" "${TARGET_SKILLS}"
+chmod 700 "${TARGET_AGENTS}" "${TARGET_SKILLS}"
+own_path "${TARGET_AGENTS}"
+HOOK_EOF
+
+sed -i "s|__TARGET_USER__|${RESOLVED_TARGET_USER}|g" /usr/local/share/agent-skills-copy.sh
+sed -i "s|__TARGET_HOME__|${RESOLVED_TARGET_HOME}|g" /usr/local/share/agent-skills-copy.sh
+chmod +x /usr/local/share/agent-skills-copy.sh
+
+echo "agent-skills installed successfully"

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -36,19 +36,23 @@ fi
 
 # Install pnpm if specified
 if [ "${INSTALL_PNPM}" = "true" ]; then
-    echo "Installing pnpm..."
-    case "${NODE_VERSION}" in
-        18|20)
-            PNPM_PACKAGE="pnpm<11"
-            ;;
-        *)
-            PNPM_PACKAGE="pnpm"
-            ;;
-    esac
+    if command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm already installed"
+    else
+        echo "Installing pnpm..."
+        case "${NODE_VERSION}" in
+            18|20)
+                PNPM_PACKAGE="pnpm<11"
+                ;;
+            *)
+                PNPM_PACKAGE="pnpm"
+                ;;
+        esac
 
-    if ! apk add --no-cache "${PNPM_PACKAGE}"; then
-        echo "Failed to install ${PNPM_PACKAGE}"
-        exit 1
+        if ! apk add --no-cache "${PNPM_PACKAGE}"; then
+            echo "Failed to install ${PNPM_PACKAGE}"
+            exit 1
+        fi
     fi
 
     if ! command -v pnpm >/dev/null 2>&1; then

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -39,12 +39,22 @@ if [ "${INSTALL_PNPM}" = "true" ]; then
     echo "Installing pnpm..."
     case "${NODE_VERSION}" in
         18|20)
-            apk add --no-cache "pnpm<11"
+            PNPM_PACKAGE="pnpm<11"
             ;;
         *)
-            apk add --no-cache pnpm
+            PNPM_PACKAGE="pnpm"
             ;;
     esac
+
+    if ! apk add --no-cache "${PNPM_PACKAGE}"; then
+        echo "Failed to install ${PNPM_PACKAGE}"
+        exit 1
+    fi
+
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm installation failed"
+        exit 1
+    fi
 fi
 
 echo "Done!"

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -36,26 +36,56 @@ fi
 
 # Install pnpm if specified
 if [ "${INSTALL_PNPM}" = "true" ]; then
-    if command -v pnpm >/dev/null 2>&1; then
-        echo "pnpm already installed"
-    else
-        echo "Installing pnpm..."
-        case "${NODE_VERSION}" in
-            18|20)
-                PNPM_PACKAGE="pnpm<11"
-                ;;
-            *)
-                PNPM_PACKAGE="pnpm"
-                ;;
-        esac
+    case "${NODE_VERSION}" in
+        18|20)
+            PNPM_PACKAGE="pnpm<11"
+            ;;
+        *)
+            PNPM_PACKAGE="pnpm"
+            ;;
+    esac
 
+    install_pnpm_package() {
+        echo "Installing ${PNPM_PACKAGE}..."
         if ! apk add --no-cache "${PNPM_PACKAGE}"; then
             echo "Failed to install ${PNPM_PACKAGE}"
             exit 1
         fi
+    }
+
+    pnpm_is_compatible() {
+        case "${NODE_VERSION}" in
+            18|20)
+                PNPM_VERSION=$(pnpm --version 2>/dev/null || true)
+                PNPM_MAJOR=${PNPM_VERSION%%.*}
+                case "${PNPM_MAJOR}" in
+                    [0-9]|10)
+                        return 0
+                        ;;
+                    *)
+                        return 1
+                        ;;
+                esac
+                ;;
+            *)
+                pnpm --version >/dev/null 2>&1
+                ;;
+        esac
+    }
+
+    if command -v pnpm >/dev/null 2>&1; then
+        if pnpm_is_compatible; then
+            echo "pnpm already installed"
+        else
+            echo "Installed pnpm is incompatible with Node.js ${NODE_VERSION}, replacing it"
+            apk del pnpm pnpm-11 pnpm-11.8 2>/dev/null || true
+            install_pnpm_package
+        fi
+    else
+        install_pnpm_package
     fi
 
-    if ! command -v pnpm >/dev/null 2>&1; then
+    if ! command -v pnpm >/dev/null 2>&1 || ! pnpm_is_compatible; then
         echo "pnpm installation failed"
         exit 1
     fi

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -37,7 +37,14 @@ fi
 # Install pnpm if specified
 if [ "${INSTALL_PNPM}" = "true" ]; then
     echo "Installing pnpm..."
-    apk add --no-cache pnpm
+    case "${NODE_VERSION}" in
+        18|20)
+            apk add --no-cache "pnpm<11"
+            ;;
+        *)
+            apk add --no-cache pnpm
+            ;;
+    esac
 fi
 
 echo "Done!"

--- a/src/opencode/NOTES.md
+++ b/src/opencode/NOTES.md
@@ -5,6 +5,7 @@
 - `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
 - `copyConfig` enables the same startup hook to copy `/tmp/opencode-host-tmp/opencode.json` into `$HOME/.config/opencode/opencode.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature.
 - Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script. The script copies `opencode.json` from `~/.config/opencode/opencode.json` and copies `auth.json` from either:
   - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
   - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).

--- a/src/opencode/README.md
+++ b/src/opencode/README.md
@@ -26,6 +26,7 @@ Installs opencode CLI on Wolfi base images.
 - `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
 - `copyConfig` enables the same startup hook to copy `/tmp/opencode-host-tmp/opencode.json` into `$HOME/.config/opencode/opencode.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature.
 - Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script. The script copies `opencode.json` from `~/.config/opencode/opencode.json` and copies `auth.json` from either:
   - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
   - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).

--- a/src/pi/NOTES.md
+++ b/src/pi/NOTES.md
@@ -5,6 +5,7 @@
 - When `pnpm` is used, the installer configures `global-bin-dir` as `/usr/local/bin` and `global-dir` as `/usr/local/share/pnpm/global` before installing Pi.
 - If `node` is already installed, the feature does not install another Node.js version. If Node tooling must be installed, `nodeVersion` selects the `nodejs-<version>` package.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/pi` to `/tmp/pi-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature. `copySkills` only copies Pi-specific skills from `~/.pi/agent/skills`.
 - Use the host scripts in `src/pi/host/pi-agent-copy` (POSIX) and `src/pi/host/pi-agent-copy.cmd` (Windows). Call the shared base name `pi-agent-copy` from `initializeCommand` so each OS resolves the right script.
 - The host helper stages supported entries from `${PI_CODING_AGENT_DIR}` when set, otherwise from `~/.pi/agent`, into `${TEMP:-/tmp}/pi/agent`. It creates the temp directory and exits successfully with a warning when Pi is not configured on the host.
 - The container startup hook copies selected entries into `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}` for the container running user.

--- a/src/pi/README.md
+++ b/src/pi/README.md
@@ -36,6 +36,7 @@ Installs Pi coding agent on Wolfi base images and optionally copies selected Pi 
 - When `pnpm` is used, the installer configures `global-bin-dir` as `/usr/local/bin` and `global-dir` as `/usr/local/share/pnpm/global` before installing Pi.
 - If `node` is already installed, the feature does not install another Node.js version. If Node tooling must be installed, `nodeVersion` selects the `nodejs-<version>` package.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/pi` to `/tmp/pi-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature. `copySkills` only copies Pi-specific skills from `~/.pi/agent/skills`.
 - Use the host scripts in `src/pi/host/pi-agent-copy` (POSIX) and `src/pi/host/pi-agent-copy.cmd` (Windows). Call the shared base name `pi-agent-copy` from `initializeCommand` so each OS resolves the right script.
 - The host helper stages supported entries from `${PI_CODING_AGENT_DIR}` when set, otherwise from `~/.pi/agent`, into `${TEMP:-/tmp}/pi/agent`. It creates the temp directory and exits successfully with a warning when Pi is not configured on the host.
 - The container startup hook copies selected entries into `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}` for the container running user.

--- a/src/pi/install.sh
+++ b/src/pi/install.sh
@@ -90,8 +90,19 @@ ensure_pnpm() {
         apk add --no-cache pnpm
     fi
 
-    export PNPM_HOME=/usr/local
-    export PATH="/usr/local/bin:${PATH}"
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm installation failed"
+        exit 1
+    fi
+
+    mkdir -p /etc/profile.d
+    cat <<'PNPM_PROFILE_EOF' > /etc/profile.d/pnpm.sh
+export PNPM_HOME="/usr/local"
+export PATH="${PNPM_HOME}/bin:${PATH}"
+PNPM_PROFILE_EOF
+
+    export PNPM_HOME="/usr/local"
+    export PATH="${PNPM_HOME}/bin:${PATH}"
     pnpm config set --global global-bin-dir /usr/local/bin
     pnpm config set --global global-dir /usr/local/share/pnpm/global
 }

--- a/src/pi/install.sh
+++ b/src/pi/install.sh
@@ -90,6 +90,8 @@ ensure_pnpm() {
         apk add --no-cache pnpm
     fi
 
+    export PNPM_HOME=/usr/local
+    export PATH="/usr/local/bin:${PATH}"
     pnpm config set --global global-bin-dir /usr/local/bin
     pnpm config set --global global-dir /usr/local/share/pnpm/global
 }

--- a/test/agent-skills/default.sh
+++ b/test/agent-skills/default.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+HOOK_TARGET_HOME=$(awk -F= '$1=="TARGET_HOME" {gsub(/"/, "", $2); print $2; exit}' /usr/local/share/agent-skills-copy.sh)
+if [ -z "${HOOK_TARGET_HOME}" ]; then
+    HOOK_TARGET_HOME="/root"
+fi
+
+TARGET_SKILLS="${HOOK_TARGET_HOME}/.agents/skills"
+
+check "copy hook installed" test -x /usr/local/share/agent-skills-copy.sh
+check "nested skill copied" test -f "${TARGET_SKILLS}/test-skill/SKILL.md"
+check "nested skill content copied" grep -q "name: test-skill" "${TARGET_SKILLS}/test-skill/SKILL.md"
+check "helper copied" test -f "${TARGET_SKILLS}/test-skill/bin/helper.sh"
+check "helper executable bit preserved" test -x "${TARGET_SKILLS}/test-skill/bin/helper.sh"
+check "stale skill removed" test ! -e "${TARGET_SKILLS}/stale-skill/SKILL.md"
+
+reportResults

--- a/test/agent-skills/default.sh
+++ b/test/agent-skills/default.sh
@@ -3,6 +3,11 @@ set -e
 
 source dev-container-features-test-lib
 
+if [ ! -f /usr/local/share/agent-skills-copy.sh ]; then
+    echo "agent-skills copy hook is missing: /usr/local/share/agent-skills-copy.sh"
+    exit 1
+fi
+
 HOOK_TARGET_HOME=$(awk -F= '$1=="TARGET_HOME" {gsub(/"/, "", $2); print $2; exit}' /usr/local/share/agent-skills-copy.sh)
 if [ -z "${HOOK_TARGET_HOME}" ]; then
     HOOK_TARGET_HOME="/root"

--- a/test/agent-skills/scenarios.json
+++ b/test/agent-skills/scenarios.json
@@ -1,0 +1,13 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "initializeCommand": {
+            "prepare-posix": "rm -rf /tmp/agent-skills && mkdir -p /tmp/agent-skills/skills/test-skill/bin && printf 'name: test-skill' > /tmp/agent-skills/skills/test-skill/SKILL.md && printf '#!/bin/sh\\necho helper\\n' > /tmp/agent-skills/skills/test-skill/bin/helper.sh && chmod 755 /tmp/agent-skills/skills/test-skill/bin/helper.sh || true"
+        },
+        "postCreateCommand": "mkdir -p /root/.agents/skills/stale-skill && printf stale > /root/.agents/skills/stale-skill/SKILL.md",
+        "features": {
+            "bash": {},
+            "agent-skills": {}
+        }
+    }
+}

--- a/test/agent-skills/scenarios.json
+++ b/test/agent-skills/scenarios.json
@@ -2,7 +2,7 @@
     "default": {
         "image": "chainguard/wolfi-base:latest",
         "initializeCommand": {
-            "prepare-posix": "rm -rf /tmp/agent-skills && mkdir -p /tmp/agent-skills/skills/test-skill/bin && printf 'name: test-skill' > /tmp/agent-skills/skills/test-skill/SKILL.md && printf '#!/bin/sh\\necho helper\\n' > /tmp/agent-skills/skills/test-skill/bin/helper.sh && chmod 755 /tmp/agent-skills/skills/test-skill/bin/helper.sh || true"
+            "prepare-posix": "rm -rf ${localEnv:TEMP:/tmp}/agent-skills && mkdir -p ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/bin && printf 'name: test-skill' > ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/SKILL.md && printf '#!/bin/sh\\necho helper\\n' > ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/bin/helper.sh && chmod 755 ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/bin/helper.sh || true"
         },
         "postCreateCommand": "mkdir -p /root/.agents/skills/stale-skill && printf stale > /root/.agents/skills/stale-skill/SKILL.md",
         "features": {


### PR DESCRIPTION
## Summary

- Add reusable `agent-skills` DevContainer feature for shared `~/.agents/skills`
- Add host staging scripts, docs, CI coverage, and scenario tests
- Cross-reference shared skills usage from Pi and opencode docs
- Include minimal pnpm compatibility fixes required for the existing Node/Pi CI matrix to pass against the current Wolfi package index

Closes #99

## CI compatibility note

The pnpm changes in `src/node/install.sh` and `src/pi/install.sh` are not part of the `agent-skills` feature behavior. They are included in this PR because adding `agent-skills` to the scenario matrix causes the full feature matrix to run, and the current Wolfi package index now resolves pnpm versions that broke existing Node 20 and Pi pnpm scenarios:

- Node 18/20 must install `pnpm<11` because pnpm 11 requires a newer Node runtime.
- Pi's pnpm install path must export/persist `PNPM_HOME` so pnpm global installs work in CI and at runtime.

Without these fixes, the new PR cannot get a green matrix even though the `agent-skills` scenario itself passes.

## Validation

- `jq empty src/agent-skills/devcontainer-feature.json test/agent-skills/scenarios.json`
- `sh -n src/agent-skills/install.sh src/agent-skills/host/agent-skills-copy src/node/install.sh src/pi/install.sh`
- `bash -n test/agent-skills/default.sh`
- `npx -y @devcontainers/cli features test -f agent-skills --skip-autogenerated --skip-duplicated .`
- `npx -y @devcontainers/cli features test -f node --filter with_pnpm --skip-autogenerated --skip-duplicated .`
- `npx -y @devcontainers/cli features test -f pi --filter with_pnpm --skip-autogenerated --skip-duplicated .`
- `npx -y @devcontainers/cli features package ./src --output-folder /tmp/devcontainer-features-package-test`

GitHub Actions matrix is green. CodeRabbit is currently rate-limited, which is a service quota failure rather than a code/test failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sharing skills from `~/.agents/skills` inside development containers.
  - Preserves skill files, executable permissions, and refreshes skills when containers start.
  - Added Windows and Linux support for staging shared skills.

- **Bug Fixes**
  - Improved pnpm setup by avoiding unnecessary reinstalls and verifying successful installation.
  - Ensured pnpm environment settings persist across shell sessions.

- **Documentation**
  - Added configuration and usage guidance for shared skills with supported tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->