### PR TITLE
Add Tailscale and T3 Code DevContainer features

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,8 @@ jobs:
           - pi
           - prek
           - python
+          - t3code
+          - tailscale
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         features:
+          - agent-skills
           - bash
           - chromium
           - common-utils

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: Pi config folder, Pi home
 The user-level shared agent skills directory at `~/.agents/skills`. It is preserved as its own directory in containers, separate from the Pi agent directory, because it is a cross-harness standard reused by tools such as Pi and opencode. Claude Code does not use this standard.
 _Avoid_: Pi skills folder, shared Pi skills
 
+**Workspace service state**:
+A host-mounted per-workspace directory that persists sensitive runtime state for tools started by a Feature, such as Tailscale node identity and T3 Code server settings.
+_Avoid_: Shared cache, Global state
+
 ## Example dialogue
 
 Developer: Should the Pi feature copy the whole Pi agent directory into the container running user's home?

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: Remote user, target user, container user
 The user-level Pi configuration directory at `~/.pi/agent` containing Pi settings, credentials, customizations, and installed Pi packages. In this repository's Pi feature discussions, `.pi/agent` means `~/.pi/agent` unless explicitly described as project-local.
 _Avoid_: Pi config folder, Pi home
 
+**Shared agent skills directory**:
+The user-level shared agent skills directory at `~/.agents/skills`. It is preserved as its own directory in containers, separate from the Pi agent directory, because it is a cross-harness standard reused by tools such as Pi and opencode. Claude Code does not use this standard.
+_Avoid_: Pi skills folder, shared Pi skills
+
 ## Example dialogue
 
 Developer: Should the Pi feature copy the whole Pi agent directory into the container running user's home?

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The following features are available:
 - [opencode](./src/opencode/README.md) - Installs opencode CLI on Wolfi base images
 - [prek](./src/prek/README.md) - Installs prek using uv tool install on Wolfi base images
 - [python](./src/python/README.md) - Installs Python and common Python utilities on Wolfi base images
+- [t3code](./src/t3code/README.md) - Installs T3 Code CLI on Wolfi base images and optionally starts a persistent headless T3 server for DevPod workspaces
+- [tailscale](./src/tailscale/README.md) - Installs Tailscale on Wolfi base images and optionally starts a userspace daemon for DevPod workspaces
 - [user](./src/user/README.md) - Manages user creation and configuration in development containers
 
 Each feature is designed to work seamlessly with Wolfi base images and provides a secure, lean development environment.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Most of the features available for devcontainers usually expect you to run a deb
 
 The following features are available:
 
+- [agent-skills](./src/agent-skills/README.md) - Copies shared agent skills into the container running user's home
 - [bash](./src/bash/README.md) - Installs bash and common shell utilities on Wolfi base images
 - [chromium](./src/chromium/README.md) - Installs Chromium browser on Wolfi base images
 - [common-utils](./src/common-utils/README.md) - Installs common command line utilities, configures users, and optionally sets up Zsh on Wolfi base images (lean Wolfi-native variant)

--- a/src/agent-skills/NOTES.md
+++ b/src/agent-skills/NOTES.md
@@ -1,0 +1,15 @@
+## Usage notes
+
+- This feature copies the shared agent skills directory standard, `~/.agents/skills`, into the container running user's home.
+- Including the feature enables copying by default; there are no options.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/agent-skills` to `/tmp/agent-skills-host-tmp`.
+- Use the host scripts in `src/agent-skills/host/agent-skills-copy` (POSIX) and `src/agent-skills/host/agent-skills-copy.cmd` (Windows). Call the shared base name `agent-skills-copy` from `initializeCommand` so each OS resolves the right script.
+- The host helper stages host `~/.agents/skills` into `${TEMP:-/tmp}/agent-skills/skills`. It creates an empty staging directory and exits successfully with a warning when shared agent skills are not configured on the host.
+- The container startup hook replaces the container running user's `~/.agents/skills` with the staged skills directory on each start.
+- Source permissions are preserved, including executable bits, and ownership is assigned to the container running user.
+
+Example `initializeCommand` (copy both host scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/agent-skills-copy"
+```

--- a/src/agent-skills/README.md
+++ b/src/agent-skills/README.md
@@ -1,0 +1,37 @@
+
+# agent-skills (agent-skills)
+
+Copies shared agent skills into the container running user's home.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/agent-skills:1": {}
+}
+```
+
+## Options
+
+This feature has no options.
+
+## Usage notes
+
+- This feature copies the shared agent skills directory standard, `~/.agents/skills`, into the container running user's home.
+- Including the feature enables copying by default; there are no options.
+- The feature bind-mounts `${localEnv:TEMP:/tmp}/agent-skills` to `/tmp/agent-skills-host-tmp`.
+- Use the host scripts in `src/agent-skills/host/agent-skills-copy` (POSIX) and `src/agent-skills/host/agent-skills-copy.cmd` (Windows). Call the shared base name `agent-skills-copy` from `initializeCommand` so each OS resolves the right script.
+- The host helper stages host `~/.agents/skills` into `${TEMP:-/tmp}/agent-skills/skills`. It creates an empty staging directory and exits successfully with a warning when shared agent skills are not configured on the host.
+- The container startup hook replaces the container running user's `~/.agents/skills` with the staged skills directory on each start.
+- Source permissions are preserved, including executable bits, and ownership is assigned to the container running user.
+
+Example `initializeCommand` (copy both host scripts into your repo, for example `.devcontainer/`):
+
+```json
+"initializeCommand": ".devcontainer/agent-skills-copy"
+```
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/agent-skills/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/agent-skills/devcontainer-feature.json
+++ b/src/agent-skills/devcontainer-feature.json
@@ -1,0 +1,16 @@
+{
+    "name": "agent-skills",
+    "id": "agent-skills",
+    "version": "1.0.0",
+    "description": "Copies shared agent skills into the container running user's home.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/agent-skills",
+    "options": {},
+    "mounts": [
+        {
+            "source": "${localEnv:TEMP:/tmp}/agent-skills",
+            "target": "/tmp/agent-skills-host-tmp",
+            "type": "bind"
+        }
+    ],
+    "postStartCommand": "/usr/local/share/agent-skills-copy.sh"
+}

--- a/src/agent-skills/host/agent-skills-copy
+++ b/src/agent-skills/host/agent-skills-copy
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+TEMP_DIR=${TEMP:-"/tmp"}
+TARGET_ROOT="${TEMP_DIR}/agent-skills"
+TARGET_SKILLS="${TARGET_ROOT}/skills"
+SOURCE_SKILLS="${HOME}/.agents/skills"
+
+mkdir -p "${TARGET_ROOT}"
+rm -rf "${TARGET_SKILLS}"
+mkdir -p "${TARGET_SKILLS}"
+
+if [ ! -d "${SOURCE_SKILLS}" ]; then
+    echo "Shared agent skills directory not found; created empty staging directory: ${SOURCE_SKILLS}"
+    exit 0
+fi
+
+cp -Rp "${SOURCE_SKILLS}/." "${TARGET_SKILLS}/"

--- a/src/agent-skills/host/agent-skills-copy.cmd
+++ b/src/agent-skills/host/agent-skills-copy.cmd
@@ -1,0 +1,22 @@
+@echo off
+setlocal
+
+set "TEMP_DIR=%TEMP%"
+if "%TEMP_DIR%"=="" set "TEMP_DIR=/tmp"
+
+set "TARGET_ROOT=%TEMP_DIR%\agent-skills"
+set "TARGET_SKILLS=%TARGET_ROOT%\skills"
+set "SOURCE_SKILLS=%USERPROFILE%\.agents\skills"
+
+if not exist "%TARGET_ROOT%" mkdir "%TARGET_ROOT%"
+if exist "%TARGET_SKILLS%" rmdir /S /Q "%TARGET_SKILLS%"
+mkdir "%TARGET_SKILLS%"
+
+if not exist "%SOURCE_SKILLS%" (
+    echo Shared agent skills directory not found; created empty staging directory: %SOURCE_SKILLS%
+    exit /B 0
+)
+
+xcopy /E /I /Y "%SOURCE_SKILLS%" "%TARGET_SKILLS%" >nul
+
+endlocal

--- a/src/agent-skills/install.sh
+++ b/src/agent-skills/install.sh
@@ -67,7 +67,7 @@ if [ ! -d "${SOURCE_SKILLS}" ]; then
 fi
 
 rm -rf "${TARGET_SKILLS}"
-cp -R "${SOURCE_SKILLS}" "${TARGET_SKILLS}"
+cp -Rp "${SOURCE_SKILLS}" "${TARGET_SKILLS}"
 chmod 700 "${TARGET_AGENTS}" "${TARGET_SKILLS}"
 own_path "${TARGET_AGENTS}"
 HOOK_EOF

--- a/src/agent-skills/install.sh
+++ b/src/agent-skills/install.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -e
+
+mkdir -p /usr/local/share
+
+RESOLVED_TARGET_USER="${_REMOTE_USER:-}"
+RESOLVED_TARGET_HOME=""
+
+if [ -n "${_REMOTE_USER_HOME:-}" ]; then
+    RESOLVED_TARGET_HOME="${_REMOTE_USER_HOME}"
+elif [ -n "${RESOLVED_TARGET_USER}" ] && id -u "${RESOLVED_TARGET_USER}" >/dev/null 2>&1; then
+    RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="${HOME}"
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] || [ -z "${RESOLVED_TARGET_HOME}" ] || [ "${RESOLVED_TARGET_HOME}" = "/root" ]; then
+    FALLBACK_USER=$(awk -F: '$3>=1000 && $1!="nobody" {print $1; exit}' /etc/passwd)
+    if [ -n "${FALLBACK_USER}" ] && id -u "${FALLBACK_USER}" >/dev/null 2>&1; then
+        RESOLVED_TARGET_USER="${FALLBACK_USER}"
+        RESOLVED_TARGET_HOME=$(awk -F: -v user="${RESOLVED_TARGET_USER}" '$1==user{print $6}' /etc/passwd)
+    fi
+fi
+
+if [ -z "${RESOLVED_TARGET_USER}" ] && [ -n "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_USER=$(awk -F: -v home="${RESOLVED_TARGET_HOME}" '$6==home{print $1; exit}' /etc/passwd)
+fi
+
+if [ -z "${RESOLVED_TARGET_HOME}" ]; then
+    RESOLVED_TARGET_HOME="/root"
+fi
+
+cat <<'HOOK_EOF' > /usr/local/share/agent-skills-copy.sh
+#!/bin/sh
+set -e
+
+SOURCE_SKILLS="/tmp/agent-skills-host-tmp/skills"
+TARGET_USER="__TARGET_USER__"
+TARGET_HOME="__TARGET_HOME__"
+TARGET_AGENTS="${TARGET_HOME}/.agents"
+TARGET_SKILLS="${TARGET_AGENTS}/skills"
+
+own_path() {
+    TARGET_PATH="$1"
+    if [ "$(id -u)" != "0" ]; then
+        return
+    fi
+
+    if [ -n "${TARGET_USER}" ] && id -u "${TARGET_USER}" >/dev/null 2>&1; then
+        TARGET_GROUP=$(id -gn "${TARGET_USER}" 2>/dev/null || true)
+        if [ -n "${TARGET_GROUP}" ]; then
+            chown -R "${TARGET_USER}:${TARGET_GROUP}" "${TARGET_PATH}"
+        else
+            chown -R "${TARGET_USER}" "${TARGET_PATH}"
+        fi
+    fi
+}
+
+mkdir -p "${TARGET_AGENTS}"
+
+if [ ! -d "${SOURCE_SKILLS}" ]; then
+    echo "Shared agent skills source directory missing, skipping copy: ${SOURCE_SKILLS}"
+    own_path "${TARGET_AGENTS}"
+    exit 0
+fi
+
+rm -rf "${TARGET_SKILLS}"
+cp -R "${SOURCE_SKILLS}" "${TARGET_SKILLS}"
+chmod 700 "${TARGET_AGENTS}" "${TARGET_SKILLS}"
+own_path "${TARGET_AGENTS}"
+HOOK_EOF
+
+sed -i "s|__TARGET_USER__|${RESOLVED_TARGET_USER}|g" /usr/local/share/agent-skills-copy.sh
+sed -i "s|__TARGET_HOME__|${RESOLVED_TARGET_HOME}|g" /usr/local/share/agent-skills-copy.sh
+chmod +x /usr/local/share/agent-skills-copy.sh
+
+echo "agent-skills installed successfully"

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -36,19 +36,23 @@ fi
 
 # Install pnpm if specified
 if [ "${INSTALL_PNPM}" = "true" ]; then
-    echo "Installing pnpm..."
-    case "${NODE_VERSION}" in
-        18|20)
-            PNPM_PACKAGE="pnpm<11"
-            ;;
-        *)
-            PNPM_PACKAGE="pnpm"
-            ;;
-    esac
+    if command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm already installed"
+    else
+        echo "Installing pnpm..."
+        case "${NODE_VERSION}" in
+            18|20)
+                PNPM_PACKAGE="pnpm<11"
+                ;;
+            *)
+                PNPM_PACKAGE="pnpm"
+                ;;
+        esac
 
-    if ! apk add --no-cache "${PNPM_PACKAGE}"; then
-        echo "Failed to install ${PNPM_PACKAGE}"
-        exit 1
+        if ! apk add --no-cache "${PNPM_PACKAGE}"; then
+            echo "Failed to install ${PNPM_PACKAGE}"
+            exit 1
+        fi
     fi
 
     if ! command -v pnpm >/dev/null 2>&1; then

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -39,12 +39,22 @@ if [ "${INSTALL_PNPM}" = "true" ]; then
     echo "Installing pnpm..."
     case "${NODE_VERSION}" in
         18|20)
-            apk add --no-cache "pnpm<11"
+            PNPM_PACKAGE="pnpm<11"
             ;;
         *)
-            apk add --no-cache pnpm
+            PNPM_PACKAGE="pnpm"
             ;;
     esac
+
+    if ! apk add --no-cache "${PNPM_PACKAGE}"; then
+        echo "Failed to install ${PNPM_PACKAGE}"
+        exit 1
+    fi
+
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm installation failed"
+        exit 1
+    fi
 fi
 
 echo "Done!"

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -36,26 +36,56 @@ fi
 
 # Install pnpm if specified
 if [ "${INSTALL_PNPM}" = "true" ]; then
-    if command -v pnpm >/dev/null 2>&1; then
-        echo "pnpm already installed"
-    else
-        echo "Installing pnpm..."
-        case "${NODE_VERSION}" in
-            18|20)
-                PNPM_PACKAGE="pnpm<11"
-                ;;
-            *)
-                PNPM_PACKAGE="pnpm"
-                ;;
-        esac
+    case "${NODE_VERSION}" in
+        18|20)
+            PNPM_PACKAGE="pnpm<11"
+            ;;
+        *)
+            PNPM_PACKAGE="pnpm"
+            ;;
+    esac
 
+    install_pnpm_package() {
+        echo "Installing ${PNPM_PACKAGE}..."
         if ! apk add --no-cache "${PNPM_PACKAGE}"; then
             echo "Failed to install ${PNPM_PACKAGE}"
             exit 1
         fi
+    }
+
+    pnpm_is_compatible() {
+        case "${NODE_VERSION}" in
+            18|20)
+                PNPM_VERSION=$(pnpm --version 2>/dev/null || true)
+                PNPM_MAJOR=${PNPM_VERSION%%.*}
+                case "${PNPM_MAJOR}" in
+                    [0-9]|10)
+                        return 0
+                        ;;
+                    *)
+                        return 1
+                        ;;
+                esac
+                ;;
+            *)
+                pnpm --version >/dev/null 2>&1
+                ;;
+        esac
+    }
+
+    if command -v pnpm >/dev/null 2>&1; then
+        if pnpm_is_compatible; then
+            echo "pnpm already installed"
+        else
+            echo "Installed pnpm is incompatible with Node.js ${NODE_VERSION}, replacing it"
+            apk del pnpm pnpm-11 pnpm-11.8 2>/dev/null || true
+            install_pnpm_package
+        fi
+    else
+        install_pnpm_package
     fi
 
-    if ! command -v pnpm >/dev/null 2>&1; then
+    if ! command -v pnpm >/dev/null 2>&1 || ! pnpm_is_compatible; then
         echo "pnpm installation failed"
         exit 1
     fi

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -37,7 +37,14 @@ fi
 # Install pnpm if specified
 if [ "${INSTALL_PNPM}" = "true" ]; then
     echo "Installing pnpm..."
-    apk add --no-cache pnpm
+    case "${NODE_VERSION}" in
+        18|20)
+            apk add --no-cache "pnpm<11"
+            ;;
+        *)
+            apk add --no-cache pnpm
+            ;;
+    esac
 fi
 
 echo "Done!"

--- a/src/opencode/NOTES.md
+++ b/src/opencode/NOTES.md
@@ -5,6 +5,7 @@
 - `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
 - `copyConfig` enables the same startup hook to copy `/tmp/opencode-host-tmp/opencode.json` into `$HOME/.config/opencode/opencode.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature.
 - Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script. The script copies `opencode.json` from `~/.config/opencode/opencode.json` and copies `auth.json` from either:
   - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
   - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).

--- a/src/opencode/README.md
+++ b/src/opencode/README.md
@@ -26,6 +26,7 @@ Installs opencode CLI on Wolfi base images.
 - `copyAuth` enables a startup hook that copies `/tmp/opencode-host-tmp/auth.json` into `$HOME/.local/share/opencode/auth.json`.
 - `copyConfig` enables the same startup hook to copy `/tmp/opencode-host-tmp/opencode.json` into `$HOME/.config/opencode/opencode.json`.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/opencode` to `/tmp/opencode-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature.
 - Use the host scripts in `src/opencode/host/opencode-auth-copy` (POSIX) and `src/opencode/host/opencode-auth-copy.cmd` (Windows). Call the shared base name `opencode-auth-copy` from `initializeCommand` so each OS resolves the right script. The script copies `opencode.json` from `~/.config/opencode/opencode.json` and copies `auth.json` from either:
   - `${OPENCODE_CONFIG_DIR}/auth.json` when `OPENCODE_CONFIG_DIR` is set, or
   - the default storage location (`~/.local/share/opencode/auth.json` on macOS/Linux, `%USERPROFILE%\.local\share\opencode\auth.json` on Windows).

--- a/src/pi/NOTES.md
+++ b/src/pi/NOTES.md
@@ -5,6 +5,7 @@
 - When `pnpm` is used, the installer configures `global-bin-dir` as `/usr/local/bin` and `global-dir` as `/usr/local/share/pnpm/global` before installing Pi.
 - If `node` is already installed, the feature does not install another Node.js version. If Node tooling must be installed, `nodeVersion` selects the `nodejs-<version>` package.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/pi` to `/tmp/pi-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature. `copySkills` only copies Pi-specific skills from `~/.pi/agent/skills`.
 - Use the host scripts in `src/pi/host/pi-agent-copy` (POSIX) and `src/pi/host/pi-agent-copy.cmd` (Windows). Call the shared base name `pi-agent-copy` from `initializeCommand` so each OS resolves the right script.
 - The host helper stages supported entries from `${PI_CODING_AGENT_DIR}` when set, otherwise from `~/.pi/agent`, into `${TEMP:-/tmp}/pi/agent`. It creates the temp directory and exits successfully with a warning when Pi is not configured on the host.
 - The container startup hook copies selected entries into `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}` for the container running user.

--- a/src/pi/README.md
+++ b/src/pi/README.md
@@ -36,6 +36,7 @@ Installs Pi coding agent on Wolfi base images and optionally copies selected Pi 
 - When `pnpm` is used, the installer configures `global-bin-dir` as `/usr/local/bin` and `global-dir` as `/usr/local/share/pnpm/global` before installing Pi.
 - If `node` is already installed, the feature does not install another Node.js version. If Node tooling must be installed, `nodeVersion` selects the `nodejs-<version>` package.
 - The feature bind-mounts `${localEnv:TEMP:/tmp}/pi` to `/tmp/pi-host-tmp`.
+- To copy shared cross-harness skills from `~/.agents/skills`, compose this feature with the `agent-skills` feature. `copySkills` only copies Pi-specific skills from `~/.pi/agent/skills`.
 - Use the host scripts in `src/pi/host/pi-agent-copy` (POSIX) and `src/pi/host/pi-agent-copy.cmd` (Windows). Call the shared base name `pi-agent-copy` from `initializeCommand` so each OS resolves the right script.
 - The host helper stages supported entries from `${PI_CODING_AGENT_DIR}` when set, otherwise from `~/.pi/agent`, into `${TEMP:-/tmp}/pi/agent`. It creates the temp directory and exits successfully with a warning when Pi is not configured on the host.
 - The container startup hook copies selected entries into `${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}` for the container running user.

--- a/src/pi/install.sh
+++ b/src/pi/install.sh
@@ -90,8 +90,19 @@ ensure_pnpm() {
         apk add --no-cache pnpm
     fi
 
-    export PNPM_HOME=/usr/local
-    export PATH="/usr/local/bin:${PATH}"
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm installation failed"
+        exit 1
+    fi
+
+    mkdir -p /etc/profile.d
+    cat <<'PNPM_PROFILE_EOF' > /etc/profile.d/pnpm.sh
+export PNPM_HOME="/usr/local"
+export PATH="${PNPM_HOME}/bin:${PATH}"
+PNPM_PROFILE_EOF
+
+    export PNPM_HOME="/usr/local"
+    export PATH="${PNPM_HOME}/bin:${PATH}"
     pnpm config set --global global-bin-dir /usr/local/bin
     pnpm config set --global global-dir /usr/local/share/pnpm/global
 }

--- a/src/pi/install.sh
+++ b/src/pi/install.sh
@@ -90,6 +90,8 @@ ensure_pnpm() {
         apk add --no-cache pnpm
     fi
 
+    export PNPM_HOME=/usr/local
+    export PATH="/usr/local/bin:${PATH}"
     pnpm config set --global global-bin-dir /usr/local/bin
     pnpm config set --global global-dir /usr/local/share/pnpm/global
 }

--- a/src/t3code/README.md
+++ b/src/t3code/README.md
@@ -1,0 +1,51 @@
+
+# t3code (t3code)
+
+Installs T3 Code CLI on Wolfi base images and optionally starts a persistent headless T3 server for DevPod workspaces.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/t3code:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select the T3 Code CLI npm package version to install. | string | latest |
+| nodeVersion | Node.js version to install when T3 Code installation requires adding Node tooling. Existing node installations are reused. | string | 24 |
+| autoStart | Whether to start a headless T3 Code server from the feature postStartCommand. | boolean | false |
+| baseDir | T3CODE_HOME/base directory for server state. Mount this from the host to persist T3 state. | string | /persist/devpod-t3/t3 |
+| host | Host/interface for the T3 server to bind. | string | 127.0.0.1 |
+| port | Port for the T3 server to listen on. | string | 3773 |
+| workspaceDir | Workspace directory passed to T3. Empty means use the postStartCommand working directory. | string |  |
+
+## Usage notes
+
+- The feature installs Node.js/npm plus native build dependencies needed by T3 Code's `node-pty` dependency, then installs the `t3` npm package globally.
+- `autoStart=false` only installs the CLI and startup hook. Set `autoStart=true` or runtime `T3CODE_AUTO_START=true` to start the server at container startup.
+- Persist `baseDir` with a host bind mount. It contains T3 settings, pairing/session state, provider settings, logs, and may contain secrets.
+- `workspaceDir` should be a path inside the DevPod workspace container. If empty, the post-start working directory is used.
+- For mobile access, compose this feature with the `tailscale` feature and expose `http://127.0.0.1:3773` through Tailscale Serve.
+
+Example DevPod overlay:
+
+```json
+{
+    "features": {
+        "ghcr.io/davzucky/devcontainers-features-wolfi/t3code:1": {
+            "autoStart": true,
+            "baseDir": "/persist/devpod-t3/t3",
+            "host": "127.0.0.1",
+            "port": "3773"
+        }
+    }
+}
+```
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/t3code/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/t3code/devcontainer-feature.json
+++ b/src/t3code/devcontainer-feature.json
@@ -1,0 +1,51 @@
+{
+    "name": "t3code",
+    "id": "t3code",
+    "version": "1.0.0",
+    "description": "Installs T3 Code CLI on Wolfi base images and optionally starts a persistent headless T3 server for DevPod workspaces.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/t3code",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Select the T3 Code CLI npm package version to install."
+        },
+        "nodeVersion": {
+            "type": "string",
+            "enum": [
+                "26",
+                "25",
+                "24",
+                "22"
+            ],
+            "default": "24",
+            "description": "Node.js version to install when T3 Code installation requires adding Node tooling. Existing node installations are reused."
+        },
+        "autoStart": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to start a headless T3 Code server from the feature postStartCommand."
+        },
+        "baseDir": {
+            "type": "string",
+            "default": "/persist/devpod-t3/t3",
+            "description": "T3CODE_HOME/base directory for server state. Mount this from the host to persist T3 state."
+        },
+        "host": {
+            "type": "string",
+            "default": "127.0.0.1",
+            "description": "Host/interface for the T3 server to bind."
+        },
+        "port": {
+            "type": "string",
+            "default": "3773",
+            "description": "Port for the T3 server to listen on."
+        },
+        "workspaceDir": {
+            "type": "string",
+            "default": "",
+            "description": "Workspace directory passed to T3. Empty means use the postStartCommand working directory."
+        }
+    },
+    "postStartCommand": "/usr/local/share/t3code-devpod-start.sh"
+}

--- a/src/t3code/install.sh
+++ b/src/t3code/install.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+set -e
+
+VERSION=${VERSION:-"latest"}
+NODE_VERSION=${NODEVERSION:-"24"}
+AUTO_START=${AUTOSTART:-"false"}
+BASE_DIR=${BASEDIR:-"/persist/devpod-t3/t3"}
+HOST=${HOST:-"127.0.0.1"}
+PORT=${PORT:-"3773"}
+WORKSPACE_DIR=${WORKSPACEDIR:-""}
+
+validate_boolean() {
+    VARIABLE_NAME="$1"
+    VARIABLE_VALUE="$2"
+    case "${VARIABLE_VALUE}" in
+        true|false)
+            ;;
+        *)
+            echo "Unsupported boolean value for ${VARIABLE_NAME}: ${VARIABLE_VALUE}"
+            exit 1
+            ;;
+    esac
+}
+
+validate_boolean AUTO_START "${AUTO_START}"
+
+case "${NODE_VERSION}" in
+    26|25|24|22)
+        ;;
+    *)
+        echo "Unsupported Node.js version: ${NODE_VERSION}"
+        exit 1
+        ;;
+esac
+
+case "${PORT}" in
+    ''|*[!0-9]*)
+        echo "port must be numeric: ${PORT}"
+        exit 1
+        ;;
+esac
+
+apk update
+apk add --no-cache ca-certificates curl build-base python-3.13
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "Installing Node.js ${NODE_VERSION}"
+    apk add --no-cache "nodejs-${NODE_VERSION}"
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "Installing npm"
+    apk add --no-cache npm
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm installation failed"
+    exit 1
+fi
+
+T3CODE_INSTALLED="false"
+if command -v t3 >/dev/null 2>&1; then
+    echo "t3 already installed, skipping package install"
+    T3CODE_INSTALLED="true"
+fi
+
+if [ "${T3CODE_INSTALLED}" = "false" ]; then
+    VERSION_TARGET="${VERSION}"
+    case "${VERSION_TARGET}" in
+        v*)
+            VERSION_TARGET=${VERSION_TARGET#v}
+            ;;
+    esac
+
+    PACKAGE_SPEC="t3@${VERSION_TARGET}"
+    echo "Installing T3 Code CLI from ${PACKAGE_SPEC}"
+    npm install -g --allow-scripts=node-pty,msgpackr-extract "${PACKAGE_SPEC}"
+fi
+
+if ! command -v t3 >/dev/null 2>&1; then
+    echo "t3 installation failed"
+    exit 1
+fi
+
+mkdir -p /usr/local/share
+
+cat <<'HOOK_EOF' > /usr/local/share/t3code-devpod-start.sh
+#!/bin/sh
+set -e
+
+AUTO_START="__AUTO_START__"
+DEFAULT_BASE_DIR="__BASE_DIR__"
+DEFAULT_HOST="__HOST__"
+DEFAULT_PORT="__PORT__"
+DEFAULT_WORKSPACE_DIR="__WORKSPACE_DIR__"
+
+AUTO_START="${T3CODE_AUTO_START:-${AUTO_START}}"
+BASE_DIR="${T3CODE_BASE_DIR:-${DEFAULT_BASE_DIR}}"
+HOST="${T3CODE_HOST:-${DEFAULT_HOST}}"
+PORT="${T3CODE_PORT:-${DEFAULT_PORT}}"
+WORKSPACE_DIR="${T3CODE_WORKSPACE_DIR:-${DEFAULT_WORKSPACE_DIR}}"
+
+if [ "${AUTO_START}" != "true" ]; then
+    exit 0
+fi
+
+if [ -z "${WORKSPACE_DIR}" ]; then
+    WORKSPACE_DIR=$(pwd)
+fi
+
+mkdir -p "${BASE_DIR}" "${BASE_DIR}/run"
+chmod 700 "${BASE_DIR}" 2>/dev/null || true
+
+PID_FILE="${BASE_DIR}/run/t3code.pid"
+LOG_FILE="${BASE_DIR}/run/t3code.log"
+
+is_running() {
+    PID=$(cat "${PID_FILE}" 2>/dev/null || true)
+    if [ -z "${PID}" ] || ! kill -0 "${PID}" 2>/dev/null; then
+        return 1
+    fi
+    curl -fsS "http://${HOST}:${PORT}/" >/dev/null 2>&1
+}
+
+if is_running; then
+    echo "T3 Code server is already running on ${HOST}:${PORT}"
+    exit 0
+fi
+
+OLD_PID=$(cat "${PID_FILE}" 2>/dev/null || true)
+if [ -n "${OLD_PID}" ] && kill -0 "${OLD_PID}" 2>/dev/null; then
+    kill "${OLD_PID}" 2>/dev/null || true
+fi
+
+mkdir -p "${WORKSPACE_DIR}"
+
+echo "Starting T3 Code server on ${HOST}:${PORT} with base directory ${BASE_DIR}"
+nohup env T3CODE_NO_BROWSER=1 t3 serve --host "${HOST}" --port "${PORT}" --base-dir "${BASE_DIR}" "${WORKSPACE_DIR}" >"${LOG_FILE}" 2>&1 < /dev/null &
+echo "$!" > "${PID_FILE}"
+
+READY=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    if curl -fsS "http://${HOST}:${PORT}/" >/dev/null 2>&1; then
+        READY=1
+        break
+    fi
+    sleep 1
+done
+
+if [ "${READY}" != "1" ]; then
+    echo "T3 Code server did not become ready; recent log output follows" >&2
+    tail -n 80 "${LOG_FILE}" >&2 2>/dev/null || true
+    exit 1
+fi
+HOOK_EOF
+
+sed -i \
+    -e "s#__AUTO_START__#${AUTO_START}#g" \
+    -e "s#__BASE_DIR__#${BASE_DIR}#g" \
+    -e "s#__HOST__#${HOST}#g" \
+    -e "s#__PORT__#${PORT}#g" \
+    -e "s#__WORKSPACE_DIR__#${WORKSPACE_DIR}#g" \
+    /usr/local/share/t3code-devpod-start.sh
+
+chmod +x /usr/local/share/t3code-devpod-start.sh
+
+echo "T3 Code installed successfully"

--- a/src/tailscale/README.md
+++ b/src/tailscale/README.md
@@ -1,0 +1,55 @@
+
+# tailscale (tailscale)
+
+Installs Tailscale on Wolfi base images and optionally starts a userspace daemon for DevPod workspaces.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/davzucky/devcontainers-features-wolfi/tailscale:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| autoStart | Whether to start tailscaled from the feature postStartCommand. | boolean | false |
+| stateDir | Directory for Tailscale socket, logs, pid, and state file. Mount this from the host to persist the node identity. | string | /persist/devpod-t3/tailscale |
+| authKeyEnvVar | Runtime environment variable containing the Tailscale auth key used for first enrollment. | string | TS_AUTHKEY |
+| hostname | Optional Tailscale hostname to use during first enrollment. | string |  |
+| advertiseTags | Optional comma-separated tags to advertise during first enrollment, for example tag:devpod-t3. | string |  |
+| tunMode | Tailscaled --tun mode. Use userspace-networking for unprivileged DevPod containers. | string | userspace-networking |
+| serveTarget | Optional local HTTP target to expose with Tailscale Serve, for example http://127.0.0.1:3773. | string |  |
+| serveHttpsPort | HTTPS port registered with Tailscale Serve when serveTarget is set. | string | 443 |
+
+## Usage notes
+
+- The feature installs `tailscale` and `tailscaled` from Wolfi packages.
+- `autoStart=false` only installs the tools and startup hook. Set `autoStart=true` or runtime `TAILSCALE_AUTO_START=true` to start `tailscaled` at container startup.
+- The startup hook uses userspace networking by default so it can run in unprivileged DevPod containers.
+- Persist `stateDir` with a host bind mount. The `tailscaled.state` file contains the workspace's Tailscale node identity and must be treated as secret state.
+- First enrollment reads the auth key from `authKeyEnvVar`, which defaults to `TS_AUTHKEY`. Do not put auth keys in the feature options.
+- `hostname` and `advertiseTags` are used with `tailscale up` during first enrollment. For DevPod T3 workspaces, use names like `t3-hawk` and `tag:devpod-t3`.
+- When `serveTarget` is set and the node is authenticated, the hook runs Tailscale Serve in the background, for example `https://t3-hawk.pixiebob-luma.ts.net` for hostname `t3-hawk`.
+
+Example DevPod overlay:
+
+```json
+{
+    "features": {
+        "ghcr.io/davzucky/devcontainers-features-wolfi/tailscale:1": {
+            "autoStart": true,
+            "stateDir": "/persist/devpod-t3/tailscale",
+            "hostname": "t3-hawk",
+            "advertiseTags": "tag:devpod-t3",
+            "serveTarget": "http://127.0.0.1:3773"
+        }
+    }
+}
+```
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/davzucky/devcontainers-features-wolfi/blob/main/src/tailscale/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -1,0 +1,54 @@
+{
+    "name": "tailscale",
+    "id": "tailscale",
+    "version": "1.0.0",
+    "description": "Installs Tailscale on Wolfi base images and optionally starts a userspace daemon for DevPod workspaces.",
+    "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/tailscale",
+    "options": {
+        "autoStart": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to start tailscaled from the feature postStartCommand."
+        },
+        "stateDir": {
+            "type": "string",
+            "default": "/persist/devpod-t3/tailscale",
+            "description": "Directory for Tailscale socket, logs, pid, and state file. Mount this from the host to persist the node identity."
+        },
+        "authKeyEnvVar": {
+            "type": "string",
+            "default": "TS_AUTHKEY",
+            "description": "Runtime environment variable containing the Tailscale auth key used for first enrollment."
+        },
+        "hostname": {
+            "type": "string",
+            "default": "",
+            "description": "Optional Tailscale hostname to use during first enrollment."
+        },
+        "advertiseTags": {
+            "type": "string",
+            "default": "",
+            "description": "Optional comma-separated tags to advertise during first enrollment, for example tag:devpod-t3."
+        },
+        "tunMode": {
+            "type": "string",
+            "enum": [
+                "userspace-networking",
+                "auto"
+            ],
+            "default": "userspace-networking",
+            "description": "Tailscaled --tun mode. Use userspace-networking for unprivileged DevPod containers."
+        },
+        "serveTarget": {
+            "type": "string",
+            "default": "",
+            "description": "Optional local HTTP target to expose with Tailscale Serve, for example http://127.0.0.1:3773."
+        },
+        "serveHttpsPort": {
+            "type": "string",
+            "default": "443",
+            "description": "HTTPS port registered with Tailscale Serve when serveTarget is set."
+        }
+    },
+    "postStartCommand": "/usr/local/share/tailscale-devpod-start.sh"
+}

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -1,0 +1,164 @@
+#!/bin/sh
+set -e
+
+AUTO_START=${AUTOSTART:-"false"}
+STATE_DIR=${STATEDIR:-"/persist/devpod-t3/tailscale"}
+AUTH_KEY_ENV_VAR=${AUTHKEYENVVAR:-"TS_AUTHKEY"}
+HOSTNAME=${HOSTNAME:-""}
+ADVERTISE_TAGS=${ADVERTISETAGS:-""}
+TUN_MODE=${TUNMODE:-"userspace-networking"}
+SERVE_TARGET=${SERVETARGET:-""}
+SERVE_HTTPS_PORT=${SERVEHTTPSPORT:-"443"}
+
+validate_boolean() {
+    VARIABLE_NAME="$1"
+    VARIABLE_VALUE="$2"
+    case "${VARIABLE_VALUE}" in
+        true|false)
+            ;;
+        *)
+            echo "Unsupported boolean value for ${VARIABLE_NAME}: ${VARIABLE_VALUE}"
+            exit 1
+            ;;
+    esac
+}
+
+validate_boolean AUTO_START "${AUTO_START}"
+
+case "${TUN_MODE}" in
+    userspace-networking|auto)
+        ;;
+    *)
+        echo "Unsupported Tailscale tun mode: ${TUN_MODE}"
+        exit 1
+        ;;
+esac
+
+case "${SERVE_HTTPS_PORT}" in
+    ''|*[!0-9]*)
+        echo "serveHttpsPort must be numeric: ${SERVE_HTTPS_PORT}"
+        exit 1
+        ;;
+esac
+
+apk update
+apk add --no-cache ca-certificates tailscale
+
+if ! command -v tailscale >/dev/null 2>&1; then
+    echo "tailscale installation failed"
+    exit 1
+fi
+
+if ! command -v tailscaled >/dev/null 2>&1; then
+    echo "tailscaled installation failed"
+    exit 1
+fi
+
+mkdir -p /usr/local/share
+
+cat <<'HOOK_EOF' > /usr/local/share/tailscale-devpod-start.sh
+#!/bin/sh
+set -e
+
+AUTO_START="__AUTO_START__"
+DEFAULT_STATE_DIR="__STATE_DIR__"
+DEFAULT_AUTH_KEY_ENV_VAR="__AUTH_KEY_ENV_VAR__"
+DEFAULT_HOSTNAME="__HOSTNAME__"
+DEFAULT_ADVERTISE_TAGS="__ADVERTISE_TAGS__"
+DEFAULT_TUN_MODE="__TUN_MODE__"
+DEFAULT_SERVE_TARGET="__SERVE_TARGET__"
+DEFAULT_SERVE_HTTPS_PORT="__SERVE_HTTPS_PORT__"
+
+AUTO_START="${TAILSCALE_AUTO_START:-${AUTO_START}}"
+STATE_DIR="${TAILSCALE_STATE_DIR:-${DEFAULT_STATE_DIR}}"
+AUTH_KEY_ENV_VAR="${TAILSCALE_AUTH_KEY_ENV_VAR:-${DEFAULT_AUTH_KEY_ENV_VAR}}"
+TAILSCALE_HOSTNAME="${TAILSCALE_HOSTNAME:-${DEFAULT_HOSTNAME}}"
+ADVERTISE_TAGS="${TAILSCALE_ADVERTISE_TAGS:-${DEFAULT_ADVERTISE_TAGS}}"
+TUN_MODE="${TAILSCALE_TUN_MODE:-${DEFAULT_TUN_MODE}}"
+SERVE_TARGET="${TAILSCALE_SERVE_TARGET:-${DEFAULT_SERVE_TARGET}}"
+SERVE_HTTPS_PORT="${TAILSCALE_SERVE_HTTPS_PORT:-${DEFAULT_SERVE_HTTPS_PORT}}"
+
+if [ "${AUTO_START}" != "true" ]; then
+    exit 0
+fi
+
+mkdir -p "${STATE_DIR}"
+chmod 700 "${STATE_DIR}" 2>/dev/null || true
+
+STATE_FILE="${STATE_DIR}/tailscaled.state"
+SOCKET_FILE="${STATE_DIR}/tailscaled.sock"
+PID_FILE="${STATE_DIR}/tailscaled.pid"
+LOG_FILE="${STATE_DIR}/tailscaled.log"
+
+daemon_ready() {
+    tailscale --socket="${SOCKET_FILE}" version --daemon >/dev/null 2>&1
+}
+
+authenticated() {
+    tailscale --socket="${SOCKET_FILE}" status --peers=false >/dev/null 2>&1
+}
+
+if ! daemon_ready; then
+    OLD_PID=$(cat "${PID_FILE}" 2>/dev/null || true)
+    if [ -n "${OLD_PID}" ] && kill -0 "${OLD_PID}" 2>/dev/null; then
+        kill "${OLD_PID}" 2>/dev/null || true
+    fi
+
+    echo "Starting tailscaled with state ${STATE_FILE}"
+    nohup tailscaled --tun="${TUN_MODE}" --state="${STATE_FILE}" --socket="${SOCKET_FILE}" >"${LOG_FILE}" 2>&1 < /dev/null &
+    echo "$!" > "${PID_FILE}"
+
+    READY=0
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if daemon_ready; then
+            READY=1
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "${READY}" != "1" ]; then
+        echo "tailscaled did not become ready; recent log output follows" >&2
+        tail -n 80 "${LOG_FILE}" >&2 2>/dev/null || true
+        exit 1
+    fi
+fi
+
+AUTH_KEY=""
+eval "AUTH_KEY=\${${AUTH_KEY_ENV_VAR}:-}"
+
+if ! authenticated && [ -n "${AUTH_KEY}" ]; then
+    UP_ARGS="--auth-key=${AUTH_KEY}"
+    if [ -n "${TAILSCALE_HOSTNAME}" ]; then
+        UP_ARGS="${UP_ARGS} --hostname=${TAILSCALE_HOSTNAME}"
+    fi
+    if [ -n "${ADVERTISE_TAGS}" ]; then
+        UP_ARGS="${UP_ARGS} --advertise-tags=${ADVERTISE_TAGS}"
+    fi
+    # shellcheck disable=SC2086
+    tailscale --socket="${SOCKET_FILE}" up ${UP_ARGS}
+fi
+
+if [ -n "${SERVE_TARGET}" ]; then
+    if ! authenticated; then
+        echo "Tailscale is not authenticated; skipping Tailscale Serve setup" >&2
+        exit 0
+    fi
+    tailscale --socket="${SOCKET_FILE}" serve --bg --https="${SERVE_HTTPS_PORT}" "${SERVE_TARGET}"
+fi
+HOOK_EOF
+
+sed -i \
+    -e "s#__AUTO_START__#${AUTO_START}#g" \
+    -e "s#__STATE_DIR__#${STATE_DIR}#g" \
+    -e "s#__AUTH_KEY_ENV_VAR__#${AUTH_KEY_ENV_VAR}#g" \
+    -e "s#__HOSTNAME__#${HOSTNAME}#g" \
+    -e "s#__ADVERTISE_TAGS__#${ADVERTISE_TAGS}#g" \
+    -e "s#__TUN_MODE__#${TUN_MODE}#g" \
+    -e "s#__SERVE_TARGET__#${SERVE_TARGET}#g" \
+    -e "s#__SERVE_HTTPS_PORT__#${SERVE_HTTPS_PORT}#g" \
+    /usr/local/share/tailscale-devpod-start.sh
+
+chmod +x /usr/local/share/tailscale-devpod-start.sh
+
+echo "Tailscale installed successfully"

--- a/test/agent-skills/default.sh
+++ b/test/agent-skills/default.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+HOOK_TARGET_HOME=$(awk -F= '$1=="TARGET_HOME" {gsub(/"/, "", $2); print $2; exit}' /usr/local/share/agent-skills-copy.sh)
+if [ -z "${HOOK_TARGET_HOME}" ]; then
+    HOOK_TARGET_HOME="/root"
+fi
+
+TARGET_SKILLS="${HOOK_TARGET_HOME}/.agents/skills"
+
+check "copy hook installed" test -x /usr/local/share/agent-skills-copy.sh
+check "nested skill copied" test -f "${TARGET_SKILLS}/test-skill/SKILL.md"
+check "nested skill content copied" grep -q "name: test-skill" "${TARGET_SKILLS}/test-skill/SKILL.md"
+check "helper copied" test -f "${TARGET_SKILLS}/test-skill/bin/helper.sh"
+check "helper executable bit preserved" test -x "${TARGET_SKILLS}/test-skill/bin/helper.sh"
+check "stale skill removed" test ! -e "${TARGET_SKILLS}/stale-skill/SKILL.md"
+
+reportResults

--- a/test/agent-skills/default.sh
+++ b/test/agent-skills/default.sh
@@ -3,6 +3,11 @@ set -e
 
 source dev-container-features-test-lib
 
+if [ ! -f /usr/local/share/agent-skills-copy.sh ]; then
+    echo "agent-skills copy hook is missing: /usr/local/share/agent-skills-copy.sh"
+    exit 1
+fi
+
 HOOK_TARGET_HOME=$(awk -F= '$1=="TARGET_HOME" {gsub(/"/, "", $2); print $2; exit}' /usr/local/share/agent-skills-copy.sh)
 if [ -z "${HOOK_TARGET_HOME}" ]; then
     HOOK_TARGET_HOME="/root"

--- a/test/agent-skills/scenarios.json
+++ b/test/agent-skills/scenarios.json
@@ -1,0 +1,13 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "initializeCommand": {
+            "prepare-posix": "rm -rf /tmp/agent-skills && mkdir -p /tmp/agent-skills/skills/test-skill/bin && printf 'name: test-skill' > /tmp/agent-skills/skills/test-skill/SKILL.md && printf '#!/bin/sh\\necho helper\\n' > /tmp/agent-skills/skills/test-skill/bin/helper.sh && chmod 755 /tmp/agent-skills/skills/test-skill/bin/helper.sh || true"
+        },
+        "postCreateCommand": "mkdir -p /root/.agents/skills/stale-skill && printf stale > /root/.agents/skills/stale-skill/SKILL.md",
+        "features": {
+            "bash": {},
+            "agent-skills": {}
+        }
+    }
+}

--- a/test/agent-skills/scenarios.json
+++ b/test/agent-skills/scenarios.json
@@ -2,7 +2,7 @@
     "default": {
         "image": "chainguard/wolfi-base:latest",
         "initializeCommand": {
-            "prepare-posix": "rm -rf /tmp/agent-skills && mkdir -p /tmp/agent-skills/skills/test-skill/bin && printf 'name: test-skill' > /tmp/agent-skills/skills/test-skill/SKILL.md && printf '#!/bin/sh\\necho helper\\n' > /tmp/agent-skills/skills/test-skill/bin/helper.sh && chmod 755 /tmp/agent-skills/skills/test-skill/bin/helper.sh || true"
+            "prepare-posix": "rm -rf ${localEnv:TEMP:/tmp}/agent-skills && mkdir -p ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/bin && printf 'name: test-skill' > ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/SKILL.md && printf '#!/bin/sh\\necho helper\\n' > ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/bin/helper.sh && chmod 755 ${localEnv:TEMP:/tmp}/agent-skills/skills/test-skill/bin/helper.sh || true"
         },
         "postCreateCommand": "mkdir -p /root/.agents/skills/stale-skill && printf stale > /root/.agents/skills/stale-skill/SKILL.md",
         "features": {

--- a/test/chromium/scenarios.json
+++ b/test/chromium/scenarios.json
@@ -6,12 +6,12 @@
             "chromium": {}
         }
     },
-    "version_144_0_7559_109_r2": {
+    "version_149_0_7827_53_r0": {
         "image": "chainguard/wolfi-base:latest",
         "features": {
             "bash": {},
             "chromium": {
-                "version": "144.0.7559.109-r2"
+                "version": "149.0.7827.53-r0"
             }
         }
     }

--- a/test/chromium/version_149_0_7827_53_r0.sh
+++ b/test/chromium/version_149_0_7827_53_r0.sh
@@ -5,6 +5,6 @@ set -e
 source dev-container-features-test-lib
 
 check "chromium package installed" apk info -e chromium
-check "chromium pinned version" bash -lc "apk list --installed chromium | grep 'chromium-144.0.7559.109-r2'"
+check "chromium pinned version" bash -lc "apk list --installed chromium | grep 'chromium-149.0.7827.53-r0'"
 
 reportResults

--- a/test/t3code/configured_autostart.sh
+++ b/test/t3code/configured_autostart.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "t3 installed" t3 --version
+check "startup hook installed" test -x /usr/local/share/t3code-devpod-start.sh
+check "configured base dir present in hook" grep -q '/tmp/devpod-t3/t3' /usr/local/share/t3code-devpod-start.sh
+check "configured port present in hook" grep -q '3773' /usr/local/share/t3code-devpod-start.sh
+check "configured workspace dir present in hook" grep -q '/workspaces/hawk' /usr/local/share/t3code-devpod-start.sh
+check "t3 server is running" curl -fsS -o /dev/null http://127.0.0.1:3773/
+
+reportResults

--- a/test/t3code/default.sh
+++ b/test/t3code/default.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "node installed" node --version
+check "npm installed" npm --version
+check "t3 installed" t3 --version
+check "startup hook installed" test -x /usr/local/share/t3code-devpod-start.sh
+check "startup hook is disabled by default" /usr/local/share/t3code-devpod-start.sh
+
+reportResults

--- a/test/t3code/scenarios.json
+++ b/test/t3code/scenarios.json
@@ -1,0 +1,22 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "t3code": {}
+        }
+    },
+    "configured_autostart": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "t3code": {
+                "autoStart": true,
+                "baseDir": "/tmp/devpod-t3/t3",
+                "host": "127.0.0.1",
+                "port": "3773",
+                "workspaceDir": "/workspaces/hawk"
+            }
+        }
+    }
+}

--- a/test/tailscale/configured_autostart.sh
+++ b/test/tailscale/configured_autostart.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "tailscale installed" tailscale version
+check "startup hook installed" test -x /usr/local/share/tailscale-devpod-start.sh
+check "configured state dir present in hook" grep -q '/tmp/devpod-t3/tailscale' /usr/local/share/tailscale-devpod-start.sh
+check "configured hostname present in hook" grep -q 't3-hawk' /usr/local/share/tailscale-devpod-start.sh
+check "configured tag present in hook" grep -q 'tag:devpod-t3' /usr/local/share/tailscale-devpod-start.sh
+check "configured serve target present in hook" grep -q 'http://127.0.0.1:3773' /usr/local/share/tailscale-devpod-start.sh
+
+reportResults

--- a/test/tailscale/default.sh
+++ b/test/tailscale/default.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source dev-container-features-test-lib
+
+check "tailscale installed" tailscale version
+check "tailscaled installed" tailscaled --version
+check "startup hook installed" test -x /usr/local/share/tailscale-devpod-start.sh
+check "startup hook is disabled by default" /usr/local/share/tailscale-devpod-start.sh
+
+reportResults

--- a/test/tailscale/scenarios.json
+++ b/test/tailscale/scenarios.json
@@ -1,0 +1,22 @@
+{
+    "default": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "tailscale": {}
+        }
+    },
+    "configured_autostart": {
+        "image": "chainguard/wolfi-base:latest",
+        "features": {
+            "bash": {},
+            "tailscale": {
+                "autoStart": true,
+                "stateDir": "/tmp/devpod-t3/tailscale",
+                "hostname": "t3-hawk",
+                "advertiseTags": "tag:devpod-t3",
+                "serveTarget": "http://127.0.0.1:3773"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Wolfi Tailscale feature with optional userspace daemon startup, persistent state, tagged enrollment, and Tailscale Serve support
- add a Wolfi T3 Code feature with optional persistent headless server startup
- document workspace service state and include both features in CI scenario coverage

Closes #101

## Tests
- npx --yes @devcontainers/cli features test -f tailscale --skip-autogenerated --skip-duplicated .
- npx --yes @devcontainers/cli features test -f t3code --skip-autogenerated --skip-duplicated .
- jq empty src/tailscale/devcontainer-feature.json src/t3code/devcontainer-feature.json test/tailscale/scenarios.json test/t3code/scenarios.json
- sh -n src/tailscale/install.sh src/t3code/install.sh
- bash -n test/tailscale/default.sh test/tailscale/configured_autostart.sh test/t3code/default.sh test/t3code/configured_autostart.sh
- git diff --check