### PR TITLE
Make T3 Code feature depend on Node feature

### DIFF
--- a/src/t3code/README.md
+++ b/src/t3code/README.md
@@ -16,7 +16,6 @@ Installs T3 Code CLI on Wolfi base images and optionally starts a persistent hea
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Select the T3 Code CLI npm package version to install. | string | latest |
-| nodeVersion | Node.js version to install when T3 Code installation requires adding Node tooling. Existing node installations are reused. | string | 24 |
 | autoStart | Whether to start a headless T3 Code server from the feature postStartCommand. | boolean | false |
 | baseDir | T3CODE_HOME/base directory for server state. Mount this from the host to persist T3 state. | string | /persist/devpod-t3/t3 |
 | host | Host/interface for the T3 server to bind. | string | 127.0.0.1 |
@@ -25,7 +24,8 @@ Installs T3 Code CLI on Wolfi base images and optionally starts a persistent hea
 
 ## Usage notes
 
-- The feature installs Node.js/npm plus native build dependencies needed by T3 Code's `node-pty` dependency, then installs the `t3` npm package globally.
+- The feature depends on this repository's `node` feature with `nodeVersion=24` and `installNpm=true`; it does not install Node.js or npm itself.
+- The feature installs native build dependencies needed by T3 Code's `node-pty` dependency, then installs the `t3` npm package globally.
 - `autoStart=false` only installs the CLI and startup hook. Set `autoStart=true` or runtime `T3CODE_AUTO_START=true` to start the server at container startup.
 - Persist `baseDir` with a host bind mount. It contains T3 settings, pairing/session state, provider settings, logs, and may contain secrets.
 - `workspaceDir` should be a path inside the DevPod workspace container. If empty, the post-start working directory is used.

--- a/src/t3code/devcontainer-feature.json
+++ b/src/t3code/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "t3code",
     "id": "t3code",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs T3 Code CLI on Wolfi base images and optionally starts a persistent headless T3 server for DevPod workspaces.",
     "documentationURL": "https://github.com/davzucky/devcontainers-features-wolfi/tree/main/src/t3code",
     "options": {
@@ -9,17 +9,6 @@
             "type": "string",
             "default": "latest",
             "description": "Select the T3 Code CLI npm package version to install."
-        },
-        "nodeVersion": {
-            "type": "string",
-            "enum": [
-                "26",
-                "25",
-                "24",
-                "22"
-            ],
-            "default": "24",
-            "description": "Node.js version to install when T3 Code installation requires adding Node tooling. Existing node installations are reused."
         },
         "autoStart": {
             "type": "boolean",
@@ -47,5 +36,11 @@
             "description": "Workspace directory passed to T3. Empty means use the postStartCommand working directory."
         }
     },
-    "postStartCommand": "/usr/local/share/t3code-devpod-start.sh"
+    "postStartCommand": "/usr/local/share/t3code-devpod-start.sh",
+    "dependsOn": {
+        "ghcr.io/davzucky/devcontainers-features-wolfi/node": {
+            "nodeVersion": "24",
+            "installNpm": true
+        }
+    }
 }

--- a/src/t3code/install.sh
+++ b/src/t3code/install.sh
@@ -104,7 +104,7 @@ is_running() {
     if [ -z "${PID}" ] || ! kill -0 "${PID}" 2>/dev/null; then
         return 1
     fi
-    curl -fsS "http://${HOST}:${PORT}/" >/dev/null 2>&1
+    curl --connect-timeout 1 --max-time 2 -fsS "http://${HOST}:${PORT}/" >/dev/null 2>&1
 }
 
 if is_running; then
@@ -125,7 +125,7 @@ echo "$!" > "${PID_FILE}"
 
 READY=0
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-    if curl -fsS "http://${HOST}:${PORT}/" >/dev/null 2>&1; then
+    if curl --connect-timeout 1 --max-time 2 -fsS "http://${HOST}:${PORT}/" >/dev/null 2>&1; then
         READY=1
         break
     fi

--- a/src/t3code/install.sh
+++ b/src/t3code/install.sh
@@ -2,7 +2,6 @@
 set -e
 
 VERSION=${VERSION:-"latest"}
-NODE_VERSION=${NODEVERSION:-"24"}
 AUTO_START=${AUTOSTART:-"false"}
 BASE_DIR=${BASEDIR:-"/persist/devpod-t3/t3"}
 HOST=${HOST:-"127.0.0.1"}
@@ -24,15 +23,6 @@ validate_boolean() {
 
 validate_boolean AUTO_START "${AUTO_START}"
 
-case "${NODE_VERSION}" in
-    26|25|24|22)
-        ;;
-    *)
-        echo "Unsupported Node.js version: ${NODE_VERSION}"
-        exit 1
-        ;;
-esac
-
 case "${PORT}" in
     ''|*[!0-9]*)
         echo "port must be numeric: ${PORT}"
@@ -44,17 +34,12 @@ apk update
 apk add --no-cache ca-certificates curl build-base python-3.13
 
 if ! command -v node >/dev/null 2>&1; then
-    echo "Installing Node.js ${NODE_VERSION}"
-    apk add --no-cache "nodejs-${NODE_VERSION}"
+    echo "node is required. Compose t3code with the node feature."
+    exit 1
 fi
 
 if ! command -v npm >/dev/null 2>&1; then
-    echo "Installing npm"
-    apk add --no-cache npm
-fi
-
-if ! command -v npm >/dev/null 2>&1; then
-    echo "npm installation failed"
+    echo "npm is required. Compose t3code with the node feature using installNpm=true."
     exit 1
 fi
 

--- a/test/t3code/configured_autostart.sh
+++ b/test/t3code/configured_autostart.sh
@@ -8,6 +8,6 @@ check "startup hook installed" test -x /usr/local/share/t3code-devpod-start.sh
 check "configured base dir present in hook" grep -q '/tmp/devpod-t3/t3' /usr/local/share/t3code-devpod-start.sh
 check "configured port present in hook" grep -q '3773' /usr/local/share/t3code-devpod-start.sh
 check "configured workspace dir present in hook" grep -q '/workspaces/hawk' /usr/local/share/t3code-devpod-start.sh
-check "t3 server is running" curl -fsS -o /dev/null http://127.0.0.1:3773/
+check "t3 server is running" curl --connect-timeout 1 --max-time 2 -fsS -o /dev/null http://127.0.0.1:3773/
 
 reportResults


### PR DESCRIPTION
## Summary
- make the t3code feature depend on the existing node feature with Node 24 and npm enabled
- remove direct Node.js/npm installation from the t3code installer
- keep native build dependencies in t3code for T3 Code's node-pty install

## Tests
- jq empty src/t3code/devcontainer-feature.json test/t3code/scenarios.json
- sh -n src/t3code/install.sh
- bash -n test/t3code/default.sh test/t3code/configured_autostart.sh
- git diff --check
- npx --yes @devcontainers/cli features test -f t3code --filter configured_autostart --skip-autogenerated --skip-duplicated .

Note: a full local t3code scenario run exceeded my 300s command timeout after the default scenario passed; the configured_autostart scenario passes independently.